### PR TITLE
Uniform sample output size

### DIFF
--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -37,7 +37,7 @@ function sample(n,lb,ub,S::GridSample)
     else
         d = length(lb)
         x = [[rand(lb[j]:dx[j]:ub[j]) for j = 1:d] for i in 1:n]
-        return reduce(hcat,x)
+        return reduce(vcat,x')
     end
 end
 
@@ -51,7 +51,7 @@ function sample(n,lb,ub,::UniformSample)
     else
         d = length(lb)
         x = [[rand(Uniform(lb[j],ub[j])) for j in 1:d] for i in 1:n]
-        return reduce(hcat,x)
+        return reduce(vcat,x')
     end
 end
 
@@ -65,7 +65,7 @@ function sample(n,lb,ub,::SobolSample)
     if lb isa Number
         return [next!(s)[1] for i = 1:n]
     else
-        return reduce(hcat,[next!(s) for i = 1:n])
+        return reduce(vcat,[next!(s) for i = 1:n]')
     end
 end
 
@@ -147,8 +147,8 @@ function sample(n,d,D::Distribution)
     if d == 1
         return rand(D,n)
     else
-        x = reduce(hcat,[[rand(D) for j in 1:d] for i in 1:n])
-        return x
+        x = [[rand(D) for j in 1:d] for i in 1:n]
+        return reduce(vcat, x')
     end
 end
 

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -37,7 +37,7 @@ function sample(n,lb,ub,S::GridSample)
     else
         d = length(lb)
         x = [[rand(lb[j]:dx[j]:ub[j]) for j = 1:d] for i in 1:n]
-        return reduce(vcat,x')
+        return reduce(hcat,x)
     end
 end
 
@@ -51,7 +51,7 @@ function sample(n,lb,ub,::UniformSample)
     else
         d = length(lb)
         x = [[rand(Uniform(lb[j],ub[j])) for j in 1:d] for i in 1:n]
-        return reduce(vcat,x')
+        return reduce(hcat,x)
     end
 end
 
@@ -65,7 +65,7 @@ function sample(n,lb,ub,::SobolSample)
     if lb isa Number
         return [next!(s)[1] for i = 1:n]
     else
-        return reduce(vcat,[next!(s) for i = 1:n]')
+        return reduce(hcat,[next!(s) for i = 1:n])
     end
 end
 
@@ -80,10 +80,10 @@ function sample(n,lb,ub,::LatinHypercubeSample)
         # x∈[0,n], so affine transform
         return @. (ub-lb) * x/(n) + lb
     else
-        lib_out = float(LHCoptim(n,d,1)[1])
+        lib_out = float(LHCoptim(d,n,1)[1])
         # x∈[0,n], so affine transform column-wise
         @inbounds for c = 1:d
-            lib_out[:,c] = (ub[c]-lb[c])*lib_out[:,c]/n .+ lb[c]
+            lib_out[c, :] = (ub[c]-lb[c])*lib_out[c, :]/n .+ lb[c]
         end
         return lib_out
     end
@@ -116,7 +116,7 @@ function sample(n,lb,ub,S::LowDiscrepancySample)
         return @. (ub-lb) * x + lb
     else
         #Halton sequence
-        x = zeros(Float32,n,d)
+        x = zeros(Float32,d,n)
         for j = 1:d
             b = S.base[j]
             for i = 1:n
@@ -127,13 +127,13 @@ function sample(n,lb,ub,S::LowDiscrepancySample)
                 for k = 1:L
                     val += expansion[k]*float(b)^(-(k-1)-1)
                 end
-                x[i,j] = val
+                x[j,i] = val
             end
         end
         #Resizing
         # x∈[0,1], so affine transform column-wise
         @inbounds for c = 1:d
-            x[:,c] = (ub[c]-lb[c])*x[:,c] .+ lb[c]
+            x[c, :] = (ub[c]-lb[c])*x[c, :] .+ lb[c]
         end
         return x
     end
@@ -148,14 +148,14 @@ function sample(n,d,D::Distribution)
         return rand(D,n)
     else
         x = [[rand(D) for j in 1:d] for i in 1:n]
-        return reduce(vcat, x')
+        return reduce(hcat, x)
     end
 end
 
 function generate_design_matrices(n,lb,ub,sampler,num_mats = 2)
     @assert length(lb) == length(ub)
     d = length(lb)
-    out = sample(n,repeat(lb,num_mats),repeat(ub,num_mats),sampler)
+    out = sample(n, repeat(lb,num_mats), repeat(ub,num_mats),sampler)
     [out[(j*d+1):((j+1)*d),:] for j in 0:num_mats-1]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,30 +20,51 @@ ub = [1.0,20.0]
 n = 5
 d = 2
 
-#GridSample{T}
-s = QuasiMonteCarlo.sample(n,lb,ub,GridSample([0.1,0.5]))
-@test isa(s,Matrix{typeof(s[1][1])}) == true
+@testset "GridSample" begin
+    #GridSample{T}
+    s = QuasiMonteCarlo.sample(n,lb,ub,GridSample([0.1,0.5]))
+    @test isa(s,Matrix{typeof(s[1][1])}) == true
+    @test size(s) == (n, d)
+end
 
-#UniformSample()
-s = QuasiMonteCarlo.sample(n,lb,ub,UniformSample())
-@test isa(s,Matrix{typeof(s[1][1])}) == true
+@testset "UniformSample" begin
+    #UniformSample()
+    s = QuasiMonteCarlo.sample(n,lb,ub,UniformSample())
+    @test isa(s,Matrix{typeof(s[1][1])}) == true
+    @test size(s) == (n, d)
+end
 
-#SobolSample()
-s = QuasiMonteCarlo.sample(n,lb,ub,SobolSample())
-@test isa(s,Matrix{typeof(s[1][1])}) == true
+@testset "SobolSample" begin
+    #SobolSample()
+    s = QuasiMonteCarlo.sample(n,lb,ub,SobolSample())
+    @test isa(s,Matrix{typeof(s[1][1])}) == true
+    @test size(s) == (n, d)
+end
 
-#LHS
-s = QuasiMonteCarlo.sample(n,lb,ub,LatinHypercubeSample())
-@test isa(s,Matrix{typeof(s[1][1])}) == true
+@testset "LHS" begin
+    #LHS
+    s = QuasiMonteCarlo.sample(n,lb,ub,LatinHypercubeSample())
+    @test isa(s,Matrix{typeof(s[1][1])}) == true
+    @test size(s) == (n, d)
+end
 
-#LDS
-s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([10,3]))
-@test isa(s,Matrix{typeof(s[1][1])}) == true
+@testset "LDS" begin
+    #LDS
+    s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([10,3]))
+    @test isa(s,Matrix{typeof(s[1][1])}) == true
+    @test size(s) == (n, d)
+end
 
-#Distribution 1
-s = QuasiMonteCarlo.sample(n,d,Cauchy())
-@test isa(s,Matrix{typeof(s[1][1])}) == true
+@testset "Distribution 1" begin
+    #Distribution 1
+    s = QuasiMonteCarlo.sample(n,d,Cauchy())
+    @test isa(s,Matrix{typeof(s[1][1])}) == true
+    @test size(s) == (n, d)
+end
 
-#Distribution 2
-s = QuasiMonteCarlo.sample(n,d,Normal(3,5))
-@test isa(s,Matrix{typeof(s[1][1])}) == true
+@testset "Distribution 2" begin
+    #Distribution 2
+    s = QuasiMonteCarlo.sample(n,d,Normal(3,5))
+    @test isa(s,Matrix{typeof(s[1][1])}) == true
+    @test size(s) == (n, d)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,47 +24,59 @@ d = 2
     #GridSample{T}
     s = QuasiMonteCarlo.sample(n,lb,ub,GridSample([0.1,0.5]))
     @test isa(s,Matrix{typeof(s[1][1])}) == true
-    @test size(s) == (n, d)
+    @test size(s) == (d, n)
 end
 
 @testset "UniformSample" begin
     #UniformSample()
     s = QuasiMonteCarlo.sample(n,lb,ub,UniformSample())
     @test isa(s,Matrix{typeof(s[1][1])}) == true
-    @test size(s) == (n, d)
+    @test size(s) == (d, n)
 end
 
 @testset "SobolSample" begin
     #SobolSample()
     s = QuasiMonteCarlo.sample(n,lb,ub,SobolSample())
     @test isa(s,Matrix{typeof(s[1][1])}) == true
-    @test size(s) == (n, d)
+    @test size(s) == (d, n)
 end
 
 @testset "LHS" begin
     #LHS
     s = QuasiMonteCarlo.sample(n,lb,ub,LatinHypercubeSample())
     @test isa(s,Matrix{typeof(s[1][1])}) == true
-    @test size(s) == (n, d)
+    @test size(s) == (d, n)
 end
 
 @testset "LDS" begin
     #LDS
     s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([10,3]))
     @test isa(s,Matrix{typeof(s[1][1])}) == true
-    @test size(s) == (n, d)
+    @test size(s) == (d, n)
 end
 
 @testset "Distribution 1" begin
     #Distribution 1
     s = QuasiMonteCarlo.sample(n,d,Cauchy())
     @test isa(s,Matrix{typeof(s[1][1])}) == true
-    @test size(s) == (n, d)
+    @test size(s) == (d, n)
 end
 
 @testset "Distribution 2" begin
     #Distribution 2
     s = QuasiMonteCarlo.sample(n,d,Normal(3,5))
     @test isa(s,Matrix{typeof(s[1][1])}) == true
-    @test size(s) == (n, d)
+    @test size(s) == (d, n)
+end
+
+@testset "generate_design_matrices" begin
+    num_mat = 3
+    Ms = QuasiMonteCarlo.generate_design_matrices(n,lb,ub,UniformSample(), num_mat)
+    @test length(Ms) == num_mat
+    A = Ms[1]
+    B = Ms[2]
+    @test isa(A, Matrix{typeof(A[1][1])}) == true
+    @test size(A) == (d, n)
+    @test isa(B, Matrix{typeof(B[1][1])}) == true
+    @test size(B) == (d, n)
 end


### PR DESCRIPTION
I noticed that the output size of `sample` for different algorithms is not uniform, which is a problem when they are changed a lot.

I edited the sample functions for GridSample, UniformSample, SobolSample and Distribution types
to achieve a common output size `(n, d)`. Here, `n` is the sample size and `d` the dimension of the sample space.

