### PR TITLE
Update QuasiMonteCarlo.jl

### DIFF
--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -81,7 +81,7 @@ function sample(n,lb,ub,::LatinHypercubeSample)
         # x∈[0,n], so affine transform
         return @. (ub-lb) * x/(n) + lb
     else
-        lib_out = float(LHCoptim(d,n,1)[1])
+        lib_out = float(LHCoptim(n,d,1)[1])
         # x∈[0,n], so affine transform column-wise
         @inbounds for c = 1:d
             lib_out[c, :] = (ub[c]-lb[c])*lib_out[c, :]/n .+ lb[c]

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -81,7 +81,7 @@ function sample(n,lb,ub,::LatinHypercubeSample)
         # x∈[0,n], so affine transform
         return @. (ub-lb) * x/(n) + lb
     else
-        lib_out = float(LHCoptim(n,d,1)[1])
+        lib_out = float(LHCoptim(n,d,1)[1])'
         # x∈[0,n], so affine transform column-wise
         @inbounds for c = 1:d
             lib_out[c, :] = (ub[c]-lb[c])*lib_out[c, :]/n .+ lb[c]

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -81,7 +81,7 @@ function sample(n,lb,ub,::LatinHypercubeSample)
         # x∈[0,n], so affine transform
         return @. (ub-lb) * x/(n) + lb
     else
-        lib_out = float(LHCoptim(n,d,1)[1])'
+        lib_out = collect(float(LHCoptim(n,d,1)[1])')
         # x∈[0,n], so affine transform column-wise
         @inbounds for c = 1:d
             lib_out[c, :] = (ub[c]-lb[c])*lib_out[c, :]/n .+ lb[c]


### PR DESCRIPTION
Bug in the LatinHyperCube code.

```
help?> LHCoptim
search: LHCoptim LHCoptim! subLHCoptim

  function LHCoptim(n::Int,d::Int,gens;   rng::U=Random.GLOBAL_RNG,
                                          popsize::Int=100,
                                          ntour::Int=2,
                                          ptour=0.8,
                                          dims::Array{T,1}=[Continuous() for i in 1:d],
                                          interSampleWeight::Float64=1.0,
                                          periodic_ae::Bool=false,
                                          ae_power::Union{Int,Float64}=2) where T <: LHCDimension where U <: AbstractRNG

  Produce an optimized Latin Hyper Cube with d dimensions and n sample points. Optimization is run for gens generations. Returns a tuple of the sample plan and the optimization fitness history.
```