### PR TITLE
Increase accuracy of LowDiscrepancySample by using Float64

### DIFF
--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -129,11 +129,11 @@ function sample(n,lb,ub,S::LowDiscrepancySample)
     if d == 1
         #Van der Corput
         b = S.base
-        x = zeros(Float32,n)
+        x = zeros(n)
         for i = 1:n
             expansion = digits(i,base = b)
             L = length(expansion)
-            val = zero(Float32)
+            val = 0.0
             for k = 1:L
                 val += expansion[k]*float(b)^(-(k-1)-1)
             end
@@ -143,14 +143,13 @@ function sample(n,lb,ub,S::LowDiscrepancySample)
         return @. (ub-lb) * x + lb
     else
         #Halton sequence
-        x = zeros(Float32,d,n)
+        x = zeros(d,n)
         for j = 1:d
             b = S.base[j]
             for i = 1:n
-                val = zero(Float32)
+                val = 0.0
                 expansion = digits(i, base = b)
                 L = length(expansion)
-                val = zero(Float32)
                 for k = 1:L
                     val += expansion[k]*float(b)^(-(k-1)-1)
                 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -125,6 +125,8 @@ Low-discrepancy sample:
 If dimension d > 1, all bases must be coprime with one other.
 """
 function sample(n,lb,ub,S::LowDiscrepancySample)
+    @assert length(lb) == length(ub)
+
     d = length(lb)
     t = float(eltype(lb)) # infer data type for return values
     if d == 1

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -126,14 +126,15 @@ If dimension d > 1, all bases must be coprime with one other.
 """
 function sample(n,lb,ub,S::LowDiscrepancySample)
     d = length(lb)
+    t = float(eltype(lb)) # infer data type for return values
     if d == 1
         #Van der Corput
         b = S.base
-        x = zeros(typeof(lb[1]), n)
+        x = zeros(t, n)
         for i = 1:n
             expansion = digits(i,base = b)
             L = length(expansion)
-            val = zero(typeof(lb[1]))
+            val = zero(t)
             for k = 1:L
                 val += expansion[k]*float(b)^(-(k-1)-1)
             end
@@ -143,11 +144,11 @@ function sample(n,lb,ub,S::LowDiscrepancySample)
         return @. (ub-lb) * x + lb
     else
         #Halton sequence
-        x = zeros(typeof(lb[1]), d,n)
+        x = zeros(t,d,n)
         for j = 1:d
             b = S.base[j]
             for i = 1:n
-                val = zero(typeof(lb[1]))
+                val = zero(t)
                 expansion = digits(i, base = b)
                 L = length(expansion)
                 for k = 1:L

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -129,11 +129,11 @@ function sample(n,lb,ub,S::LowDiscrepancySample)
     if d == 1
         #Van der Corput
         b = S.base
-        x = zeros(n)
+        x = zeros(typeof(lb[1]), n)
         for i = 1:n
             expansion = digits(i,base = b)
             L = length(expansion)
-            val = 0.0
+            val = zero(typeof(lb[1]))
             for k = 1:L
                 val += expansion[k]*float(b)^(-(k-1)-1)
             end
@@ -143,11 +143,11 @@ function sample(n,lb,ub,S::LowDiscrepancySample)
         return @. (ub-lb) * x + lb
     else
         #Halton sequence
-        x = zeros(d,n)
+        x = zeros(typeof(lb[1]), d,n)
         for j = 1:d
             b = S.base[j]
             for i = 1:n
-                val = 0.0
+                val = zero(typeof(lb[1]))
                 expansion = digits(i, base = b)
                 L = length(expansion)
                 for k = 1:L

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,9 +11,22 @@ QuasiMonteCarlo.sample(n,lb,ub,UniformSample())
 QuasiMonteCarlo.sample(n,lb,ub,SobolSample())
 QuasiMonteCarlo.sample(n,lb,ub,LatinHypercubeSample())
 QuasiMonteCarlo.sample(n,lb,ub,LatticeRuleSample())
-QuasiMonteCarlo.sample(20,lb,ub,LowDiscrepancySample(10))
 QuasiMonteCarlo.sample(5,d,Cauchy())
 QuasiMonteCarlo.sample(5,d,Normal(0,4))
+
+@testset "1D" begin
+    @testset "LowDiscrepancySample" begin
+        s = QuasiMonteCarlo.sample(n, 0.0, 1.0, LowDiscrepancySample(2))
+        @test isa(s, Vector{Float64})
+        @test size(s) == (n,)
+        @test s ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
+
+        s = QuasiMonteCarlo.sample(n, zero(Float32), one(Float32), LowDiscrepancySample(2))
+        @test isa(s, Vector{Float32})
+        @test size(s) == (n,)
+        @test s ≈ [0.5, 0.25, 0.75, 0.125, 0.625] rtol = 1e-7
+    end
+end
 
 #ND
 lb = [0.0,0.0]
@@ -59,10 +72,16 @@ end
 @testset "LDS" begin
     #LDS
     s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([2,3]))
-    @test isa(s,Matrix)
+    @test isa(s,Matrix{Float64})
     @test size(s) == (d, n)
     @test s[1, :] ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
     @test s[2, :] ≈ [1/3, 2/3, 1/9, 4/9, 7/9]
+
+    s = QuasiMonteCarlo.sample(n,zeros(Float32, 2),ones(Float32, 2),LowDiscrepancySample([2,3]))
+    @test isa(s,Matrix{Float32})
+    @test size(s) == (d, n)
+    @test s[1, :] ≈ [0.5, 0.25, 0.75, 0.125, 0.625] rtol = 1e-7
+    @test s[2, :] ≈ [1/3, 2/3, 1/9, 4/9, 7/9] rtol = 1e-7
 end
 
 @testset "Distribution 1" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,8 @@ QuasiMonteCarlo.sample(5,d,Cauchy())
 QuasiMonteCarlo.sample(5,d,Normal(0,4))
 
 #ND
-lb = [0.1,-0.5]
-ub = [1.0,20.0]
+lb = [0 0]
+ub = [1 1]
 n = 5
 d = 2
 
@@ -58,9 +58,11 @@ end
 
 @testset "LDS" begin
     #LDS
-    s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([10,3]))
-    @test isa(s,Matrix{typeof(s[1][1])}) == true
+    s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([2,3]))
+    @test isa(s,Matrix)
     @test size(s) == (d, n)
+    @test s[1, :] ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
+    @test s[2, :] ≈ [1/3, 2/3, 1/9, 4/9, 7/9]
 end
 
 @testset "Distribution 1" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,8 @@ QuasiMonteCarlo.sample(5,d,Cauchy())
 QuasiMonteCarlo.sample(5,d,Normal(0,4))
 
 #ND
-lb = [0 0]
-ub = [1 1]
+lb = [0.0,0.0]
+ub = [1.0,1.0]
 n = 5
 d = 2
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,11 @@ QuasiMonteCarlo.sample(5,d,Normal(0,4))
         @test size(s) == (n,)
         @test s ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
 
+        s = QuasiMonteCarlo.sample(n, 0, 1, LowDiscrepancySample(2))
+        @test isa(s, Vector{Float64})
+        @test size(s) == (n,)
+        @test s ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
+
         s = QuasiMonteCarlo.sample(n, zero(Float32), one(Float32), LowDiscrepancySample(2))
         @test isa(s, Vector{Float32})
         @test size(s) == (n,)
@@ -72,6 +77,12 @@ end
 @testset "LDS" begin
     #LDS
     s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([2,3]))
+    @test isa(s,Matrix{Float64})
+    @test size(s) == (d, n)
+    @test s[1, :] ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
+    @test s[2, :] ≈ [1/3, 2/3, 1/9, 4/9, 7/9]
+
+    s = QuasiMonteCarlo.sample(n,Int.(lb),Int.(ub),LowDiscrepancySample([2,3]))
     @test isa(s,Matrix{Float64})
     @test size(s) == (d, n)
     @test s[1, :] ≈ [0.5, 0.25, 0.75, 0.125, 0.625]


### PR DESCRIPTION
LowDiscrepancySample was using `Float32` explicitly which leads to unnecessary inaccuracies. I could see no reason for it to be this way. All the other sampling schemes seem to return `Float64` matrices.

I also updated the tests for LDS to compare the actual expected values instead of simply checking matrix dimension.