### PR TITLE
Fix bug in SectionSample when d > 2

### DIFF
--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -277,9 +277,6 @@ function sample(n,lb,ub,section_sampler::SectionSample)
         d_free = free_dimensions(section_sampler)
         new_samples = sample(n, lb[d_free], ub[d_free], section_sampler.sa)
         out_as_vec = collect(repeat(section_sampler.x0', n, 1)')
-
-        @show size(new_samples)
-        @show size(out_as_vec, 2)
         for y in 1:size(out_as_vec,2)
             for (xi, d) in enumerate(d_free)
                 out_as_vec[d,y] = new_samples[xi, y]

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -277,9 +277,12 @@ function sample(n,lb,ub,section_sampler::SectionSample)
         d_free = free_dimensions(section_sampler)
         new_samples = sample(n, lb[d_free], ub[d_free], section_sampler.sa)
         out_as_vec = collect(repeat(section_sampler.x0', n, 1)')
+
+        @show size(new_samples)
+        @show size(out_as_vec, 2)
         for y in 1:size(out_as_vec,2)
             for (xi, d) in enumerate(d_free)
-                out_as_vec[d,y] = new_samples[y][xi]
+                out_as_vec[d,y] = new_samples[xi, y]
             end
         end
         return out_as_vec

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,6 +152,10 @@ end
 end
 
 @testset "Section Sample" begin
+    lb = [0.0,0.0]
+    ub = [1.0,1.0]
+    n = 5
+    d = 2
     constrained_val = 1.0
     sampler = SectionSample([NaN64, constrained_val], UniformSample())
     s = QuasiMonteCarlo.sample(n, lb, ub, sampler)
@@ -161,6 +165,21 @@ end
     @test all(lb[1] .≤ s[1, :] .≤ ub[1])
     @test QuasiMonteCarlo.fixed_dimensions(sampler) == [2]
     @test QuasiMonteCarlo.free_dimensions(sampler) == [1]
+
+    constrained_val = 2.0
+    d = 3
+    sampler = SectionSample([NaN64, constrained_val, NaN64], SobolSample())
+    @test QuasiMonteCarlo.free_dimensions(sampler) == [1, 3]
+    @test QuasiMonteCarlo.fixed_dimensions(sampler) == [2]
+    lb = [-1.0,constrained_val,-1.0]
+    ub = [6.0,constrained_val,6.0]
+    s = QuasiMonteCarlo.sample(n, lb, ub, sampler)
+
+    @test all(lb[1] .≤ s[1, :] .≤ ub[1])
+    @test all(lb[3] .≤ s[3, :] .≤ ub[3])
+    @test all(s[2, :] .== constrained_val)
+    @test isa(s, Matrix{Float64})
+    @test size(s) == (d, n)
 end
 
 @testset "generate_design_matrices" begin


### PR DESCRIPTION
When updating SectionSample to generate matrices instead of tuples, I inadvertently created an indexing bug that I didn't catch until trying to make tests pass for Surrogates.jl. This PR fixes that bug.