### PR TITLE
Add Cranley-Patterson rotation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,14 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LatinHypercubeSampling = "a5e1c1ea-c99a-51d3-a14d-a9a37257b02d"
 LatticeRules = "73f95e8e-ec14-4e6a-8b18-0d2e271c4e55"
 Sobol = "ed01d8cd-4d21-5b2a-85b4-cc3bdc58bad4"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Distributions = "0.21, 0.22, 0.23, 0.24, 0.25"
 LatinHypercubeSampling = "1.2"
 LatticeRules = "0.0.1"
 Sobol = "1.3"
+StatsBase = "0.33"
 julia = "1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ s = QuasiMonteCarlo.sample(n,lb,ub,UniformSample())
 s = QuasiMonteCarlo.sample(n,lb,ub,SobolSample())
 s = QuasiMonteCarlo.sample(n,lb,ub,LatinHypercubeSample())
 s = QuasiMonteCarlo.sample(n,lb,ub,LatticeRuleSample())
-s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([10,3]))
+s = QuasiMonteCarlo.sample(n,lb,ub,LowDiscrepancySample([10,3], false))
 ```
 
 The output `s` is a matrix, so one can use things like `@uview` from

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -69,8 +69,9 @@ struct LowDiscrepancySample{T} <: SamplingAlgorithm
 
 `base[i]` is the base in the ith direction.
 """
-struct LowDiscrepancySample{T} <: SamplingAlgorithm
+struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
     base::T
+    cp::V = false
 end
 
 """
@@ -224,7 +225,7 @@ Low-discrepancy sample:
 - Dimension > 1: Halton sequence
 If dimension d > 1, all bases must be coprime with one other.
 """
-function sample(n, lb, ub, S::LowDiscrepancySample, cp==false)
+function sample(n, lb, ub, S::LowDiscrepancySample)
     @assert length(lb) == length(ub)
 
     d = length(lb)
@@ -264,7 +265,7 @@ function sample(n, lb, ub, S::LowDiscrepancySample, cp==false)
         @inbounds for c in 1:d
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
-        y = (cp == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
+        y = (S.cp == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
         return y
     end
 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -64,10 +64,14 @@ struct LatticeRuleSample <: SamplingAlgorithm end
 
 """
 ```julia
-struct LowDiscrepancySample{T} <: SamplingAlgorithm
+struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
 ```
 
 `base[i]` is the base in the ith direction.
+`rotation` can be `true` or `false`.  
+
+It contains the [Cranley-Patterson rotations](https://psychopath.io/post/2014_06_28_low_discrepancy_sequences), which can improve Quasi-Monte Carlo integral
+estimates done with LowDiscrepancy sequences (only Halton, in this case)
 """
 Base.@kwdef struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
     base::T

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -75,7 +75,7 @@ estimates done with LowDiscrepancy sequences (only Halton, in this case)
 """
 Base.@kwdef struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
     base::T
-    rotation::V = false
+    rotation::V
 end
 
 """
@@ -270,8 +270,11 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
         rotation = S.rotation
-        y = (rotation == false) ? x : (x .+ rand(d, 1)) .% 1.0
-                                                                                        
+        if (rotation == false)                                                                                
+            x
+        else
+            (x .+ rand(d, 1)) .% 1.0
+        end                                                                                  
         return y
     end
 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -69,9 +69,9 @@ struct LowDiscrepancySample{T} <: SamplingAlgorithm
 
 `base[i]` is the base in the ith direction.
 """
-struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
+struct LowDiscrepancySample{T} <: SamplingAlgorithm
     base::T
-    rotation::V = false
+    cprotation = false
 end
 
 """
@@ -265,7 +265,7 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
         @inbounds for c in 1:d
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
-        y = (S.rotation == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
+        y = (S.cprotation == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
         return y
     end
 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -231,7 +231,7 @@ Low-discrepancy sample:
 - Dimension > 1: Halton sequence
 If dimension d > 1, all bases must be coprime with one other.
 """
-function sample(n, lb, ub, cp = false, S::LowDiscrepancySample)
+function sample(n, lb, ub, S::LowDiscrepancySample)
     @assert length(lb) == length(ub)
 
     d = length(lb)

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -73,7 +73,7 @@ struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
 It contains the [Cranley-Patterson rotations](https://psychopath.io/post/2014_06_28_low_discrepancy_sequences), which can improve Quasi-Monte Carlo integral
 estimates done with LowDiscrepancy sequences (only Halton, in this case)
 """
-Base.@kwdef struct LowDiscrepancySample{T,V} <: SamplingAlgorithm
+struct LowDiscrepancySample{T,V} <: SamplingAlgorithm
     base::T
     rotation::V
 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -73,7 +73,7 @@ struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
 It contains the [Cranley-Patterson rotations](https://psychopath.io/post/2014_06_28_low_discrepancy_sequences), which can improve Quasi-Monte Carlo integral
 estimates done with LowDiscrepancy sequences (only Halton, in this case)
 """
-Base.@kwdef struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
+Base.@kwdef struct LowDiscrepancySample{T,V} <: SamplingAlgorithm
     base::T
     rotation::V
 end
@@ -92,7 +92,7 @@ struct KroneckerSample{A,B} <: SamplingAlgorithm
 
 `KroneckerSample(alpha, s0)` for a Kronecker sequence, where alpha is an length-d vector of irrational numbers (often sqrt(d)) and s0 is a length-d seed vector (often 0).
 """
-struct KroneckerSample{A, B} <: SamplingAlgorithm
+struct KroneckerSample{A,B} <: SamplingAlgorithm
     alpha::A
     s0::B
 end
@@ -141,7 +141,7 @@ function sample(n, lb, ub, S::GridSample)
         return vec(rand(lb:(S.dx):ub, n))
     else
         d = length(lb)
-        x = [[rand(lb[j]:dx[j]:ub[j]) for j in 1:d] for i in 1:n]
+        x = [[rand(lb[j]:dx[j]:ub[j]) for j = 1:d] for i = 1:n]
         return reduce(hcat, x)
     end
 end
@@ -155,7 +155,7 @@ function sample(n, lb, ub, ::UniformSample)
         return rand(Uniform(lb, ub), n)
     else
         d = length(lb)
-        x = [[rand(Uniform(lb[j], ub[j])) for j in 1:d] for i in 1:n]
+        x = [[rand(Uniform(lb[j], ub[j])) for j = 1:d] for i = 1:n]
         return reduce(hcat, x)
     end
 end
@@ -168,9 +168,9 @@ function sample(n, lb, ub, ::SobolSample)
     s = SobolSeq(lb, ub)
     skip(s, n)
     if lb isa Number
-        return [next!(s)[1] for i in 1:n]
+        return [next!(s)[1] for i = 1:n]
     else
-        return reduce(hcat, [next!(s) for i in 1:n])
+        return reduce(hcat, [next!(s) for i = 1:n])
     end
 end
 
@@ -188,7 +188,7 @@ function sample(n, lb, ub, T::LatinHypercubeSample)
     else
         lib_out = collect(float(LHCoptim(n, d, 1; threading = threading)[1])')
         # x∈[0,n], so affine transform column-wise
-        @inbounds for c in 1:d
+        @inbounds for c = 1:d
             lib_out[c, :] = (ub[c] - lb[c]) * lib_out[c, :] / n .+ lb[c]
         end
         return lib_out
@@ -204,7 +204,7 @@ function sample(n, lb, ub, ::LatticeRuleSample)
         lat = ShiftedLatticeRule(1)
         pts = reduce(vcat, Iterators.take(lat, n))
         # transform from [0, 1] to [lb, ub]
-        @inbounds for i in 1:n
+        @inbounds for i = 1:n
             pts[i] = (ub - lb) * pts[i] + lb
         end
         return pts
@@ -213,8 +213,8 @@ function sample(n, lb, ub, ::LatticeRuleSample)
         lat = ShiftedLatticeRule(d)
         pts = reduce(hcat, Iterators.take(lat, n))
         # transform from [0, 1]^d to [lb, ub]
-        @inbounds for j in 1:n
-            for i in 1:d
+        @inbounds for j = 1:n
+            for i = 1:d
                 pts[i, j] = (ub[i] - lb[i]) * pts[i, j] + lb[i]
             end
         end
@@ -238,11 +238,11 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
         #Van der Corput
         b = S.base
         x = zeros(t, n)
-        for i in 1:n
+        for i = 1:n
             expansion = digits(i, base = b)
             L = length(expansion)
             val = zero(t)
-            for k in 1:L
+            for k = 1:L
                 val += expansion[k] * float(b)^(-(k - 1) - 1)
             end
             x[i] = val
@@ -252,13 +252,13 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
     else
         #Halton sequence
         x = zeros(t, d, n)
-        for j in 1:d
+        for j = 1:d
             b = S.base[j]
-            for i in 1:n
+            for i = 1:n
                 val = zero(t)
                 expansion = digits(i, base = b)
                 L = length(expansion)
-                for k in 1:L
+                for k = 1:L
                     val += expansion[k] * float(b)^(-(k - 1) - 1)
                 end
                 x[j, i] = val
@@ -266,15 +266,15 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
         end
         #Resizing
         # x∈[0,1], so affine transform column-wise
-        @inbounds for c in 1:d
+        @inbounds for c = 1:d
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
         rotation = S.rotation
-        if (rotation == false)                                                                                
+        if (rotation == false)
             x
         else
             (x .+ rand(d, 1)) .% 1.0
-        end                                                                                  
+        end
         return y
     end
 end
@@ -290,25 +290,25 @@ function sample(n, lb, ub, K::KroneckerSample)
     s0 = K.s0
     if d == 1
         x = zeros(n)
-        @inbounds for i in 1:n
+        @inbounds for i = 1:n
             x[i] = (s0 + i * alpha) % 1
         end
         return @. (ub - lb) * x + lb
     else
         x = zeros(n, d)
-        @inbounds for j in 1:d
-            for i in 1:n
+        @inbounds for j = 1:d
+            for i = 1:n
                 x[i, j] = (s0[j] + i * alpha[j]) % i
             end
         end
         #Resizing
         # x∈[0,1], so affine transform column-wise
-        @inbounds for c in 1:d
+        @inbounds for c = 1:d
             x[:, c] = (ub[c] - lb[c]) * x[:, c] .+ lb[c]
         end
 
         y = collect(x')
-                                                                                                                
+
         return y
     end
 end
@@ -319,24 +319,24 @@ function sample(n, lb, ub, G::GoldenSample)
         x = zeros(n)
         g = (sqrt(5) + 1) / 2
         a = 1.0 / g
-        for i in 1:n
+        for i = 1:n
             x[i] = (0.5 + a * i) % 1
         end
         return @. (ub - lb) * x + lb
     else
         x = zeros(n, d)
-        for j in 1:d
+        for j = 1:d
             #Approximate solution of x^(d+1) = x + 1, a simple newton is good enough
             y = 2.0
-            for s in 1:10
+            for s = 1:10
                 g = (1 + y)^(1 / (j + 1))
             end
             a = 1.0 / g
-            for i in 1:n
+            for i = 1:n
                 x[i, j] = (0.5 + a * i) % 1
             end
         end
-        @inbounds for c in 1:d
+        @inbounds for c = 1:d
             x[:, c] = (ub[c] - lb[c]) * x[:, c] .+ lb[c]
         end
         y = collect(x')
@@ -344,11 +344,11 @@ function sample(n, lb, ub, G::GoldenSample)
     end
 end
 
-fixed_dimensions(section_sampler::SectionSample)::Vector{Int64} = findall(x -> x == false,
-                                                                          isnan.(section_sampler.x0))
+fixed_dimensions(section_sampler::SectionSample)::Vector{Int64} =
+    findall(x -> x == false, isnan.(section_sampler.x0))
 
-free_dimensions(section_sampler::SectionSample)::Vector{Int64} = findall(x -> x == true,
-                                                                         isnan.(section_sampler.x0))
+free_dimensions(section_sampler::SectionSample)::Vector{Int64} =
+    findall(x -> x == true, isnan.(section_sampler.x0))
 
 """
 sample(n,lb,ub,K::SectionSample)
@@ -375,7 +375,7 @@ function sample(n, lb, ub, section_sampler::SectionSample)
         d_free = free_dimensions(section_sampler)
         new_samples = sample(n, lb[d_free], ub[d_free], section_sampler.sa)
         out_as_vec = collect(repeat(section_sampler.x0', n, 1)')
-        for y in 1:size(out_as_vec, 2)
+        for y = 1:size(out_as_vec, 2)
             for (xi, d) in enumerate(d_free)
                 out_as_vec[d, y] = new_samples[xi, y]
             end
@@ -392,7 +392,7 @@ function sample(n, d, D::Distribution)
     if d == 1
         return rand(D, n)
     else
-        x = [[rand(D) for j in 1:d] for i in 1:n]
+        x = [[rand(D) for j = 1:d] for i = 1:n]
         return reduce(hcat, x)
     end
 end
@@ -410,10 +410,18 @@ function generate_design_matrices(n, lb, ub, sampler, num_mats = 2)
     @assert length(lb) == length(ub)
     d = length(lb)
     out = sample(n, repeat(lb, num_mats), repeat(ub, num_mats), sampler)
-    [out[(j * d + 1):((j + 1) * d), :] for j in 0:(num_mats - 1)]
+    [out[(j*d+1):((j+1)*d), :] for j = 0:(num_mats-1)]
 end
 
-export GridSample, UniformSample, SobolSample, LatinHypercubeSample, LatticeRuleSample,
-       RandomSample, LowDiscrepancySample, GoldenSample, KroneckerSample, SectionSample
+export GridSample,
+    UniformSample,
+    SobolSample,
+    LatinHypercubeSample,
+    LatticeRuleSample,
+    RandomSample,
+    LowDiscrepancySample,
+    GoldenSample,
+    KroneckerSample,
+    SectionSample
 
 end # module

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -69,9 +69,9 @@ struct LowDiscrepancySample{T} <: SamplingAlgorithm
 
 `base[i]` is the base in the ith direction.
 """
-struct LowDiscrepancySample{T} <: SamplingAlgorithm
+Base.@kwdef struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
     base::T
-    cprotation = false
+    rotation::V = false
 end
 
 """
@@ -265,7 +265,7 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
         @inbounds for c in 1:d
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
-        y = (S.cprotation == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
+        y = (S.rotation == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
         return y
     end
 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -69,9 +69,9 @@ struct LowDiscrepancySample{T} <: SamplingAlgorithm
 
 `base[i]` is the base in the ith direction.
 """
-struct LowDiscrepancySample{T} <: SamplingAlgorithm
+struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
     base::T
-    cp::Bool = false
+    rotation::V = false
 end
 
 """
@@ -265,7 +265,7 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
         @inbounds for c in 1:d
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
-        y = (S.cp == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
+        y = (S.rotation == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
         return y
     end
 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -264,7 +264,7 @@ function sample(n, lb, ub, S::LowDiscrepancySample, cp==false)
         @inbounds for c in 1:d
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
-        y = (cp == false) ? x: (x .+ rand(d, 1)) .% 1.0                                                                        
+        y = (cp == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
         return y
     end
 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -69,9 +69,9 @@ struct LowDiscrepancySample{T} <: SamplingAlgorithm
 
 `base[i]` is the base in the ith direction.
 """
-struct LowDiscrepancySample{T, V} <: SamplingAlgorithm
+struct LowDiscrepancySample{T} <: SamplingAlgorithm
     base::T
-    cp::V = false
+    cp::Bool = false
 end
 
 """

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -265,7 +265,9 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
         @inbounds for c in 1:d
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
-        y = (S.rotation == false) ? x : (x .+ rand(d, 1)) .% 1.0                                                                        
+        rotation = S.rotation
+        y = (rotation == false) ? x : (x .+ rand(d, 1)) .% 1.0
+                                                                                        
         return y
     end
 end
@@ -299,6 +301,7 @@ function sample(n, lb, ub, K::KroneckerSample)
         end
 
         y = collect(x')
+                                                                                                                
         return y
     end
 end

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -224,7 +224,7 @@ Low-discrepancy sample:
 - Dimension > 1: Halton sequence
 If dimension d > 1, all bases must be coprime with one other.
 """
-function sample(n, lb, ub, S::LowDiscrepancySample)
+function sample(n, lb, ub, S::LowDiscrepancySample, cp==false)
     @assert length(lb) == length(ub)
 
     d = length(lb)
@@ -264,7 +264,8 @@ function sample(n, lb, ub, S::LowDiscrepancySample)
         @inbounds for c in 1:d
             x[c, :] = (ub[c] - lb[c]) * x[c, :] .+ lb[c]
         end
-        return x
+        y = (cp == false) ? x: (x .+ rand(d, 1)) .% 1.0                                                                        
+        return y
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,8 @@ QuasiMonteCarlo.sample(5, d, Normal(0, 4))
         @test size(s) == (n,)
         @test s ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
 
-        s = QuasiMonteCarlo.sample(n, zero(Float32), one(Float32), LowDiscrepancySample(2, false))
+        s = QuasiMonteCarlo.sample(n, zero(Float32), one(Float32),
+                                   LowDiscrepancySample(2, false))
         @test isa(s, Vector{Float32})
         @test size(s) == (n,)
         @test s≈[0.5, 0.25, 0.75, 0.125, 0.625] rtol=1e-7
@@ -125,10 +126,13 @@ end
     @test size(s) == (d, n)
     @test s[1, :]≈[0.5, 0.25, 0.75, 0.125, 0.625] rtol=1e-7
     @test s[2, :]≈[1 / 3, 2 / 3, 1 / 9, 4 / 9, 7 / 9] rtol=1e-7
-    
+
     testsample = []
-    for i in 1:1000000 push!(testsample, mean(QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], true)))) end
-    @test round(mean(testsample), sigdigits=1) ≈ 0.5 rtol=1e-7
+    for i in 1:1000000
+        push!(testsample,
+              mean(QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], true))))
+    end
+    @test round(mean(testsample), sigdigits = 1)≈0.5 rtol=1e-7
 end
 
 @testset "Distribution 1" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using QuasiMonteCarlo, Distributions, Test
+using QuasiMonteCarlo, Distributions, StatsBase
 using Test
 
 #1D
@@ -125,6 +125,11 @@ end
     @test size(s) == (d, n)
     @test s[1, :]≈[0.5, 0.25, 0.75, 0.125, 0.625] rtol=1e-7
     @test s[2, :]≈[1 / 3, 2 / 3, 1 / 9, 4 / 9, 7 / 9] rtol=1e-7
+    
+    sample = []
+    s = QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], true))
+    for i in 1:1000000 push!(sample, mean(s)) end
+    @test mean(sample) ≈ 0.5 rtol=1e-5
 end
 
 @testset "Distribution 1" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,20 +107,20 @@ end
 
 @testset "LDS" begin
     #LDS
-    s = QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3]))
+    s = QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], false))
     @test isa(s, Matrix{Float64})
     @test size(s) == (d, n)
     @test s[1, :] ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
     @test s[2, :] ≈ [1 / 3, 2 / 3, 1 / 9, 4 / 9, 7 / 9]
 
-    s = QuasiMonteCarlo.sample(n, Int.(lb), Int.(ub), LowDiscrepancySample([2, 3]))
+    s = QuasiMonteCarlo.sample(n, Int.(lb), Int.(ub), LowDiscrepancySample([2, 3], false))
     @test isa(s, Matrix{Float64})
     @test size(s) == (d, n)
     @test s[1, :] ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
     @test s[2, :] ≈ [1 / 3, 2 / 3, 1 / 9, 4 / 9, 7 / 9]
 
     s = QuasiMonteCarlo.sample(n, zeros(Float32, 2), ones(Float32, 2),
-                               LowDiscrepancySample([2, 3]))
+                               LowDiscrepancySample([2, 3], false))
     @test isa(s, Matrix{Float32})
     @test size(s) == (d, n)
     @test s[1, :]≈[0.5, 0.25, 0.75, 0.125, 0.625] rtol=1e-7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -128,7 +128,7 @@ end
     
     testsample = []
     for i in 1:1000000 push!(testsample, mean(QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], true)))) end
-    @test mean(testsample) ≈ 0.5 rtol=1e-4
+    @test round(mean(testsample), sigdigits=1) ≈ 0.5 rtol=1e-7
 end
 
 @testset "Distribution 1" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -128,7 +128,7 @@ end
     
     testsample = []
     for i in 1:1000000 push!(testsample, mean(QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], true)))) end
-    @test mean(testsample) ≈ 0.5 rtol=1e-5
+    @test mean(testsample) ≈ 0.5 rtol=1e-4
 end
 
 @testset "Distribution 1" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,10 +126,9 @@ end
     @test s[1, :]≈[0.5, 0.25, 0.75, 0.125, 0.625] rtol=1e-7
     @test s[2, :]≈[1 / 3, 2 / 3, 1 / 9, 4 / 9, 7 / 9] rtol=1e-7
     
-    sample = []
-    s = QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], true))
-    for i in 1:1000000 push!(sample, mean(s)) end
-    @test mean(sample) ≈ 0.5 rtol=1e-5
+    testsample = []
+    for i in 1:1000000 push!(testsample, mean(QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], true)))) end
+    @test mean(testsample) ≈ 0.5 rtol=1e-5
 end
 
 @testset "Distribution 1" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,17 +16,17 @@ QuasiMonteCarlo.sample(5, d, Normal(0, 4))
 
 @testset "1D" begin
     @testset "LowDiscrepancySample" begin
-        s = QuasiMonteCarlo.sample(n, 0.0, 1.0, LowDiscrepancySample(2))
+        s = QuasiMonteCarlo.sample(n, 0.0, 1.0, LowDiscrepancySample(2, false))
         @test isa(s, Vector{Float64})
         @test size(s) == (n,)
         @test s ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
 
-        s = QuasiMonteCarlo.sample(n, 0, 1, LowDiscrepancySample(2))
+        s = QuasiMonteCarlo.sample(n, 0, 1, LowDiscrepancySample(2, false))
         @test isa(s, Vector{Float64})
         @test size(s) == (n,)
         @test s ≈ [0.5, 0.25, 0.75, 0.125, 0.625]
 
-        s = QuasiMonteCarlo.sample(n, zero(Float32), one(Float32), LowDiscrepancySample(2))
+        s = QuasiMonteCarlo.sample(n, zero(Float32), one(Float32), LowDiscrepancySample(2, false))
         @test isa(s, Vector{Float32})
         @test size(s) == (n,)
         @test s≈[0.5, 0.25, 0.75, 0.125, 0.625] rtol=1e-7


### PR DESCRIPTION
Hi everyone, I hope this finds you well!

[Cranley-Patterson rotations](https://psychopath.io/post/2014_06_28_low_discrepancy_sequences) can improve Quasi-Monte Carlo integral
estimates done with LowDiscrepancy sequences (only Halton, in this case). Here we have the estimation of the integral of x between 0 and 1, which is exactly 0.5:

```julia
julia> using StatsBase
julia> using QuasiMonteCarlo
julia> s = QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], false)) ### without cp rotation
2×5 Matrix{Float64}:
 0.5       0.25      0.75      0.125     0.625
 0.333333  0.666667  0.111111  0.444444  0.777778
julia> mean(s)
0.4583333333333333
julia> sample = []
julia> for i in 1:1000 push!(sample, mean(QuasiMonteCarlo.sample(n, lb, ub, LowDiscrepancySample([2, 3], true)))) end ### with cp rotation
julia> mean(sample)
0.5034462835936092
```

We can affirm that results obtained with CP rotations are more accurate! 😄 

Please, tell me if you have reviews, questions or comments.
Thanks for the attention!

