### PR TITLE
update Documentation, readme and docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dev/
 
 .vscode/
+docs/Manifest.toml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # QuasiMonteCarlo.jl
 
 [![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
@@ -88,7 +89,7 @@ Sampling methods `SamplingAlgorithm` are divided into two subtypes
   - `LatticeRuleSample` for a randomly-shifted rank-1 lattice rule.
   - `HaltonSample` for the Halton sequence.
   - `GoldenSample` for a Golden Ratio sequence.
-  - `KroneckerSample(alpha, s0)` for a Kronecker sequence, where alpha is an length-`d` vector of irrational numbers (often `sqrt(d)`) and `s0` is a length-`d` seed vector (often `0`).
+  - `KroneckerSample(alpha, s0)` for a Kronecker sequence, where alpha is a length-`d` vector of irrational numbers (often `sqrt(d)`) and `s0` is a length-`d` seed vector (often `0`).
 - `RandomSamplingAlgorithm`
   - `UniformSample` for uniformly distributed random numbers.
   - `LatinHypercubeSample` for a Latin Hypercube.
@@ -122,7 +123,7 @@ end
 
 ## Randomization of QMC sequences
 
-Most of the previous methods are deterministic i.e. `sample(n, d, Sampler()::DeterministicSamplingAlgorithm)` always produces the same sequence $X = (X_1, \dots, X_n)$.
+Most of the previous methods are deterministic, i.e. `sample(n, d, Sampler()::DeterministicSamplingAlgorithm)` always produces the same sequence $X = (X_1, \dots, X_n)$.
 There are two ways to obtain a randomized sequence:
 
 - Either directly use `QuasiMonteCarlo.sample(n, d, DeterministicSamplingAlgorithm(R = RandomizationMethod()))` or `sample(n, lb, up, DeterministicSamplingAlgorithm(R = RandomizationMethod()))`.
@@ -134,8 +135,8 @@ The currently available randomization methods are:
 `pad` is generally chosen as $\gtrsim \log_b(n)$.
 The implemented `ScramblingMethods` are
   - `DigitalShift`
-  - `MatousekScramble` a.k.a Linear Matrix Scramble.
-  - `OwenScramble` a.k.a Nested Uniform Scramble is the most understood theoretically but is more costly to operate.
+  - `MatousekScramble` a.k.a. Linear Matrix Scramble.
+  - `OwenScramble` a.k.a. Nested Uniform Scramble is the most understood theoretically, but is more costly to operate.
 - `Shift(rng)` a.k.a. Cranley Patterson Rotation.
 
 For numerous independent randomization, use `generate_design_matrices(n, d, ::DeterministicSamplingAlgorithm), ::RandomizationMethod, num_mats)` where `num_mats` is the number of independent `X` generated.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
-QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Documenter = "0.27"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -3,5 +3,6 @@
 pages = [
     "Home" => "index.md",
     "samplers.md",
-    "randomization.md"
+    "randomization.md",
+    "design_matrix.md"
 ]

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -3,5 +3,5 @@
 pages = [
     "Home" => "index.md",
     "samplers.md",
-    "randomization.md",
+    "randomization.md"
 ]

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -4,5 +4,5 @@ pages = [
     "Home" => "index.md",
     "samplers.md",
     "randomization.md",
-    "design_matrix.md"
+    "design_matrix.md",
 ]

--- a/docs/src/design_matrix.md
+++ b/docs/src/design_matrix.md
@@ -1,4 +1,4 @@
-# Design Matrices
+# [Design Matrices](@id DesignMatrices)
 
 ## API
 

--- a/docs/src/design_matrix.md
+++ b/docs/src/design_matrix.md
@@ -1,9 +1,10 @@
+
 # [Design Matrices](@id DesignMatrices)
 
 ## API
 
 It is often convenient to generate multiple independent sequence, for error estimation (uncertainty quantification).
-The resulting sequences can be stored in what is often called Design Matrices.
+The resulting sequences can be stored in what is often called a design matrix.
 In this package, this is achieved with the `generate_design_matrices(n, d, ::DeterministicSamplingAlgorithm), ::RandomizationMethod, num_mats)` function. `num_mats` is the number of independent realization. The resulting design matrix is a vector of matrix of length `num_mats`.
 
 ```@docs
@@ -11,7 +12,7 @@ QuasiMonteCarlo.generate_design_matrices
 ```
 
 !!! warning
-    The method `generate_design_matrices(n, d, sampler, R::NoRand, num_mats, T = Float64)` is an ad hoc way to produce a Design Matrix. Indeed, it creates a deterministic point set in dimension `d × num_mats` and split it in `num_mats` point set of dimension `d`. This resulting sequences have no QMC guarantees.
+    The method `generate_design_matrices(n, d, sampler, R::NoRand, num_mats, T = Float64)` is an ad hoc way to produce a Design Matrix. Indeed, it creates a deterministic point set in dimension `d × num_mats` and splits it into `num_mats` point set of dimension `d`. The resulting sequences have no QMC guarantees.
     This seems to have been proposed in Section 5.1 of [*Saltelli, A. et al. (2010)*](https://d1wqtxts1xzle7.cloudfront.net/76482087/PUBLISHED_PAPER-libre.pdf?1639660270=&response-content-disposition=inline%3B+filename%3DVariance_based_sensitivity_analysis_of_m.pdf&Expires=1685981169&Signature=aim5tHldlkb0ewZ9-gSMZsW2F1b88tLvV8euV1FpD61UYrE1mLR3RDERut0BsHNbcibjKQnF1JlsZ8mtEx~E1~eI3A~SOSySbpQllIpbhu556pFGUvD3GV5M6ghwa-5QMDP3-aQczBzflR721N4PCVJgqfmV-y94pkijQYvHSvZaPKb-tsoS8TVxE6H31Ptk4u662H61ofKzXR5JCHv0740qkQ0hORH~GqXOt8s7yQMVWYswZT4pWGSkJ9EehEQHCLo2uDVW-YSopwlSaaMRz~~0O~hkGAVE8sC~TAB7b5KnUgtNXl0jYTfGNTYO4GNJo1XhmHwj~Og~sBLDIXDxsg__&Key-Pair-Id=APKAJLOHF5GGSLRBV4ZA)[^1] to do uncertainty quantification.
 
 [^1]: Saltelli, A., Annoni, P., Azzini, I., Campolongo, F., Ratto, M., & Tarantola, S. (2010). Variance based sensitivity analysis of model output. Design and estimator for the total sensitivity index. Computer physics communications, 181(2), 259-270.

--- a/docs/src/design_matrix.md
+++ b/docs/src/design_matrix.md
@@ -1,0 +1,32 @@
+# Design Matrices
+
+## API
+
+It is often convenient to generate multiple independent sequence, for error estimation (uncertainty quantification).
+The resulting sequences can be stored in what is often called Design Matrices.
+In this package, this is achieved with the `generate_design_matrices(n, d, ::DeterministicSamplingAlgorithm), ::RandomizationMethod, num_mats)` function. `num_mats` is the number of independent realization. The resulting design matrix is a vector of matrix of length `num_mats`.
+
+```@docs
+QuasiMonteCarlo.generate_design_matrices
+```
+
+!!! warning
+    The method `generate_design_matrices(n, d, sampler, R::NoRand, num_mats, T = Float64)` is an ad hoc way to produce a Design Matrix. Indeed, it creates a deterministic point set in dimension `d × num_mats` and split it in `num_mats` point set of dimension `d`. This resulting sequences have no QMC guarantees.
+    This seems to have been proposed in Section 5.1 of [*Saltelli, A. et al. (2010)*](https://d1wqtxts1xzle7.cloudfront.net/76482087/PUBLISHED_PAPER-libre.pdf?1639660270=&response-content-disposition=inline%3B+filename%3DVariance_based_sensitivity_analysis_of_m.pdf&Expires=1685981169&Signature=aim5tHldlkb0ewZ9-gSMZsW2F1b88tLvV8euV1FpD61UYrE1mLR3RDERut0BsHNbcibjKQnF1JlsZ8mtEx~E1~eI3A~SOSySbpQllIpbhu556pFGUvD3GV5M6ghwa-5QMDP3-aQczBzflR721N4PCVJgqfmV-y94pkijQYvHSvZaPKb-tsoS8TVxE6H31Ptk4u662H61ofKzXR5JCHv0740qkQ0hORH~GqXOt8s7yQMVWYswZT4pWGSkJ9EehEQHCLo2uDVW-YSopwlSaaMRz~~0O~hkGAVE8sC~TAB7b5KnUgtNXl0jYTfGNTYO4GNJo1XhmHwj~Og~sBLDIXDxsg__&Key-Pair-Id=APKAJLOHF5GGSLRBV4ZA)[^1] to do uncertainty quantification.
+
+[^1]: Saltelli, A., Annoni, P., Azzini, I., Campolongo, F., Ratto, M., & Tarantola, S. (2010). Variance based sensitivity analysis of model output. Design and estimator for the total sensitivity index. Computer physics communications, 181(2), 259-270.
+
+## Example
+
+```@example 2
+using QuasiMonteCarlo, Random
+Random.seed!(1234)
+m = 4
+d = 3
+b = QuasiMonteCarlo.nextprime(d)
+N = b^m # Number of points
+pad = m # Can also choose something as `2m` to get "better" randomization
+
+# 5 independent Randomized Faure sequences
+QuasiMonteCarlo.generate_design_matrices(N, d, FaureSample(R = OwenScramble(base = b, pad = m)), 5)
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,9 @@ using Pkg
 Pkg.add("QuasiMonteCarlo")
 ```
 
-## Example
+## Get Started
+
+### Basic API
 
 ```julia
 using QuasiMonteCarlo, Distributions
@@ -38,7 +40,7 @@ using UnsafeArrays
 @uview s[:,i]
 ```
 
-## Toy application MC vs QMC
+### MC vs QMC
 
 We illustrate the gain of QMC methods over plain Monte Carlo using the 5-dimensional example from Section 15.9 in the [book by A. Owen](https://artowen.su.domains/mc/qmcstuff.pdf).
 ```@example MCvsQMC; continued = true

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,6 +38,54 @@ using UnsafeArrays
 @uview s[:,i]
 ```
 
+## Toy application MC vs QMC
+
+We illustrate the gain of QMC methods over plain Monte Carlo using the 5-dimensional example from Section 15.9 in the [book by A. Owen](https://artowen.su.domains/mc/qmcstuff.pdf).
+```@example MCvsQMC; continued = true
+f₁(𝐱) = prod(1 + √(12)/5*(xⱼ - 1/2) for xⱼ ∈ 𝐱)
+μ_exact = 1 # = ∫ f₁(𝐱) d⁵𝐱
+```
+
+One can estimate the integral $\mu$ using plain Monte Carlo, or Quasi Monte Carlo or Randomized Quasi Monte Carlo. See the other section of this documentation for more information on the functions used in the example.
+
+```@example MCvsQMC
+using QuasiMonteCarlo, Random, Distributions
+using Plots; default(fontfamily="Computer Modern")
+Random.seed!(1234)
+d = 5 # Dimension (= prime base for Faure net)
+b = 2 # Base for Sobol net
+m_max = 19
+m_max_Faure = 8
+N = b^m_max
+
+# Generate sequences
+seq_MC = QuasiMonteCarlo.sample(N, d, Uniform()) # Monte Carlo i.i.d Uniform sampling
+seq_QMC_Sobol = QuasiMonteCarlo.sample(N, d, SobolSample()) # Sobol net
+seq_RQMC_Sobol = QuasiMonteCarlo.sample(N, d, SobolSample(R = OwenScramble(base = b, pad = 32))) # Randomized version of Sobol net
+seq_RQMC_Faure = QuasiMonteCarlo.sample(d^m_max_Faure, d, FaureSample(R = OwenScramble(base = d, pad = 32))) # Randomized version of Faure net
+
+# Estimate the integral for different n with different estimator μ̂ₙ
+μ_MC = [mean(f₁(x) for x in eachcol(seq_MC[:, 1:b^m])) for m in 1:m_max]
+μ_QMC_Sobol = [mean(f₁(x) for x in eachcol(seq_QMC_Sobol[:, 1:b^m])) for m in 1:m_max]
+μ_RQMC_Sobol = [mean(f₁(x) for x in eachcol(seq_RQMC_Sobol[:, 1:b^m])) for m in 1:m_max]
+μ_RQMC_Faure = [mean(f₁(x) for x in eachcol(seq_RQMC_Faure[:, 1:d^m])) for m in 1:m_max_Faure]
+
+# Plot the error |μ̂-μ| vs n
+plot(b.^(1:m_max), abs.(μ_MC .- μ_exact), label="MC")
+plot!(b.^(1:m_max), abs.(μ_QMC_Sobol .- μ_exact), label="QMC Sobol")
+plot!(b.^(1:m_max), abs.(μ_RQMC_Sobol .- μ_exact), label="RQMC Sobol")
+plot!(d .^(1:m_max_Faure), abs.(μ_RQMC_Faure .- μ_exact), label="RQMC Faure")
+plot!(n -> n^(-1/2), b.^(1:m_max), c = :black, s = :dot, label = "n^(-1/2)")
+plot!(n -> n^(-3/2), b.^(1:m_max), c = :black, s = :dash, label = "n^(-3/2)") 
+# n^(-3/2) is the theoretical scaling for scrambled nets e.g. Theorem 17.5. in https://artowen.su.domains/mc/qmcstuff.pdf
+xlims!(1, 1e6)
+ylims!(1e-9, 1)
+xaxis!(:log10)
+yaxis!(:log10)
+xlabel!("n", legend = :bottomleft)
+ylabel!("|μ̂-μ|")
+```
+
 ## Adding a new sampling method
 
 Adding a new sampling method is a two-step process:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,12 +21,12 @@ ub = [1.0,20.0]
 n = 5
 d = 2
 
-s = QuasiMonteCarlo.sample(n,lb,ub,GridSample([0.1,0.5]))
-s = QuasiMonteCarlo.sample(n,lb,ub,UniformSample())
+s = QuasiMonteCarlo.sample(n,lb,ub,GridSample())
+s = QuasiMonteCarlo.sample(n,lb,ub,Uniform())
 s = QuasiMonteCarlo.sample(n,lb,ub,SobolSample())
 s = QuasiMonteCarlo.sample(n,lb,ub,LatinHypercubeSample())
 s = QuasiMonteCarlo.sample(n,lb,ub,LatticeRuleSample())
-s = QuasiMonteCarlo.sample(n,lb,ub,HaltonSample([10,3]))
+s = QuasiMonteCarlo.sample(n,lb,ub,HaltonSample())
 ```
 
 The output `s` is a matrix, so one can use things like `@uview` from

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,68 +62,83 @@ function sample(n,lb,ub,::NewAmazingSamplingAlgorithm)
     end
 end
 ```
+
 ## Contributing
 
 - Please refer to the
   [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md)
   for guidance on PRs, issues, and other matters relating to contributing to SciML.
 - There are a few community forums:
-    - the #diffeq-bridged channel in the [Julia Slack](https://julialang.org/slack/)
-    - [JuliaDiffEq](https://gitter.im/JuliaDiffEq/Lobby) on Gitter
-    - on the [Julia Discourse forums](https://discourse.julialang.org)
-    - see also [SciML Community page](https://sciml.ai/community/)
+  - the #diffeq-bridged channel in the [Julia Slack](https://julialang.org/slack/)
+  - [JuliaDiffEq](https://gitter.im/JuliaDiffEq/Lobby) on Gitter
+  - on the [Julia Discourse forums](https://discourse.julialang.org)
+  - see also [SciML Community page](https://sciml.ai/community/)
 
 ## Reproducibility
+
 ```@raw html
 <details><summary>The documentation of this SciML package was built using these direct dependencies,</summary>
 ```
+
 ```@example
 using Pkg # hide
 Pkg.status() # hide
 ```
+
 ```@raw html
 </details>
 ```
+
 ```@raw html
 <details><summary>and using this machine and Julia version.</summary>
 ```
+
 ```@example
 using InteractiveUtils # hide
 versioninfo() # hide
 ```
+
 ```@raw html
 </details>
 ```
+
 ```@raw html
 <details><summary>A more complete overview of all dependencies and their versions is also provided.</summary>
 ```
+
 ```@example
 using Pkg # hide
 Pkg.status(;mode = PKGMODE_MANIFEST) # hide
 ```
+
 ```@raw html
 </details>
 ```
+
 ```@raw html
 You can also download the
 <a href="
 ```
+
 ```@eval
 using TOML
 version = TOML.parse(read("../../Project.toml",String))["version"]
 name = TOML.parse(read("../../Project.toml",String))["name"]
 link = "https://github.com/SciML/"*name*".jl/tree/gh-pages/v"*version*"/assets/Manifest.toml"
 ```
+
 ```@raw html
 ">manifest</a> file and the
 <a href="
 ```
+
 ```@eval
 using TOML
 version = TOML.parse(read("../../Project.toml",String))["version"]
 name = TOML.parse(read("../../Project.toml",String))["name"]
 link = "https://github.com/SciML/"*name*".jl/tree/gh-pages/v"*version*"/assets/Project.toml"
 ```
+
 ```@raw html
 ">project</a> file.
 ```

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -81,14 +81,6 @@ OwenScramble
 Shift
 ```
 
-## Design Matrices
-
-For multiple independent randomization, use `generate_design_matrices(n, d, ::DeterministicSamplingAlgorithm), ::RandomizationMethod, num_mats)` where `num_mats` is the number of independent `X` generated.
-
-```@docs
-QuasiMonteCarlo.generate_design_matrices
-```
-
 ## Example
 
 Randomization of a Faure sequence with various methods.

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -33,9 +33,9 @@ randomize
 The `pad` is generally chosen as $\gtrsim \log_b(n)$.
 
 !!! warning
-    In principle, the base `b` used for the scrambling method `ScramblingMethods(b, pad, rng)` can be an arbitrary integer, however to preserve discrepancy properties, it must match the base of the sequence to scramble.
-
-    For example, (deterministic) Sobol' sequence are base $b=2$, $(t,m,d)$ sequences while (deterministic) Faure sequences are $(t,m,d)$ sequences in prime base i.e. $b$ is a prime number.
+    In principle, the base `b` used for scrambling methods `ScramblingMethods(b, pad, rng)` can be an arbitrary integer.
+    However, to preserve good Quasi Monte Carlo properties, it must match the base of the sequence to scramble.
+    For example, (deterministic) Sobol' sequence are base $b=2$, $(t,m,d)$ sequences while (deterministic) Faure sequences are $(t,m,d)$ sequences in prime base i.e. $b$ is an arbitrary prime number.
 
 The implemented `ScramblingMethods` are
 
@@ -67,10 +67,10 @@ Shift
 
 ## Design Matrices
 
-For numerous independent randomization, use `generate_design_matrices(n, d, ::DeterministicSamplingAlgorithm), ::RandomizationMethod, num_mats)` where `num_mats` is the number of independent `X` generated.
+For multiple independent randomization, use `generate_design_matrices(n, d, ::DeterministicSamplingAlgorithm), ::RandomizationMethod, num_mats)` where `num_mats` is the number of independent `X` generated.
 
 ```@docs
-generate_design_matrices
+QuasiMonteCarlo.generate_design_matrices
 ```
 
 ## Example
@@ -88,7 +88,7 @@ b = QuasiMonteCarlo.nextprime(d)
 N = b^m # Number of points
 pad = m # Can also choose something as `2m` to get "better" randomization
 
-# Unrandomized low discrepency sequence
+# Unrandomized low discrepancy sequence
 x_faure = QuasiMonteCarlo.sample(N, d, FaureSample())
 
 # Randomized version
@@ -130,11 +130,11 @@ plot(p..., size=(800, 600))
 
 ### $(t,m,d)$-net visualization
 
-<!-- TODO add precise ref for this kind of plot + `istms` net function + post into the pkg to say we are using -->
+<!-- TODO post into the pkg to say we are using -->
 
-Faure nets and scrambled versions of Faure nets are still digital $(t,m,d)$-net, it means that they have strong equipartition properties.
-On the following plot, we can (visually) verify that with Nested Uniform Scrambling (it also works with Linear Matrix Scrambling and Digital Shift).
-You must see one point per rectangle of volume $1/b^m$. Points on the "left" border of rectangles are included while those on the "right" are excluded.
+Faure nets and its scrambled versions are digital $(t,m,d)$-net, it means that they have strong equipartition properties.
+On the following plot, we can (visually) verify that with Nested Uniform Scrambling, it also works with Linear Matrix Scrambling and Digital Shift.
+You must see one point per rectangle of volume $1/b^m$. Points on the "left" border of rectangles are included while those on the "right" are excluded. See [Chapter 15.7](https://artowen.su.domains/mc/qmcstuff.pdf) and Figure 15.10 for more details.
 
 ```@example 1
 d1 = 1 
@@ -155,3 +155,7 @@ for i in 0:m
 end
 plot(p..., size=(800, 600))
 ```
+
+!!! note
+    To check if a point set is a $(t,m,d)$-net, you can use the function `istmsnet` defined in the [tests](https://github.com/SciML/QuasiMonteCarlo.jl/blob/2dce9905e564a85e1280115cc8af071674fc7d80/test/runtests.jl#L34) of this package. 
+    It uses the excellent [IntervalArithmetic.jl](https://github.com/JuliaIntervals/IntervalArithmetic.jl) package.

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -37,6 +37,16 @@ NoRand
 
 To obtain multiple independent randomization of a sequence, i.e. Design Matrices, look at the [Design Matrices section](@ref DesignMatrices).
 
+!!! note
+    In most other QMC packages, randomization is performed "online" as the points are samples. Here, randomization is performed after the deterministic sequence is generated. Both methods are useful in different contexts, the former is generally faster to produce one randomized sequence, while the latter is faster to produce independent realization of the sequence.
+
+    **PRs are welcomed** to add "online" version of the sequence! See [this comment for inspiration](https://github.com/SciML/QuasiMonteCarlo.jl/pull/57#issuecomment-1326662016).
+
+    Another way to view the two approaches is: given a computational budget of $N$ points, one can
+    1. Put all of it into a sequence of size, $N$, thus having the best estimator $\hat{\mu}_N$. The price to pay is that this estimation is not associated with a variance estimation.
+    2. Divided your computational budget into $N = n\times M$ to get $M$ independent estimator $\hat{\mu}_n$. From there one can compute an empirical variance of the estimator.
+
+
 ## Scrambling methods
 
 ```julia

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -46,7 +46,6 @@ To obtain multiple independent randomization of a sequence, i.e. Design Matrices
     1. Put all of it into a sequence of size, $N$, thus having the best estimator $\hat{\mu}_N$. The price to pay is that this estimation is not associated with a variance estimation.
     2. Divided your computational budget into $N = n\times M$ to get $M$ independent estimator $\hat{\mu}_n$. From there one can compute an empirical variance of the estimator.
 
-
 ## Scrambling methods
 
 ```julia

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -1,8 +1,8 @@
-# Randomization methods
+# [Randomization methods](@id Randomization)
 
 Most of the methods presented in [Sampler](@ref Samplers) are deterministic i.e. `X = sample(n, d, ::DeterministicSamplingAlgorithm)` will always produce the same sequence $X = (X_1, \dots, X_n)$.
 
-The main issue with deterministic Quasi Monte Carlo sampling is that it does not allow easy error estimation as opposed to plain Monte Carlo where the variance can be estimated. 
+The main issue with deterministic Quasi Monte Carlo sampling is that it does not allow easy error estimation as opposed to plain Monte Carlo where the variance can be estimated.
 
 A Randomized Quasi Monte Carlo method must respect the two following criteria:
 
@@ -13,12 +13,16 @@ This randomized version is unbiased and can be used to obtain confidence interva
 
 A good reference is the [book by A. Owen](https://artowen.su.domains/mc/qmcstuff.pdf), especially the Chapters 15, 16 and 17.
 
-## API
+## API for randomization
+
+```julia
+abstract type RandomizationMethod end
+```
 
 There are two ways to obtain a randomized sequence:
 
-- Either directly use `QuasiMonteCarlo.sample(n, d, DeterministicSamplingAlgorithm(R = RandomizationMethod()))` or `sample(n, lb, up, DeterministicSamplingAlgorithm(R = RandomizationMethod()))`.
-- Or, given $n$ points $d$-dimensional points, all in $[0,1]^d$ one can do `randomize(X, ::RandomizationMethod())` where $X$ is a $d\times n$-matrix.
+- Either directly use `QuasiMonteCarlo.sample(n, d, DeterministicSamplingAlgorithm(R = SomeRandomizationMethod()))` or `sample(n, lb, up, DeterministicSamplingAlgorithm(R = RandomizationMethod()))`.
+- Or, given $n$ points $d$-dimensional points, all in $[0,1]^d$ one can do `randomize(X, SomeRandomizationMethod())` where $X$ is a $d\times n$-matrix.
 
 ```@docs
 randomize
@@ -31,6 +35,10 @@ NoRand
 ```
 
 ## Scrambling methods
+
+```julia
+abstract type ScrambleMethod <: RandomizationMethod end
+```
 
 ```@docs
 ScrambleMethod
@@ -163,5 +171,5 @@ plot(p..., size=(800, 600))
 ```
 
 !!! note
-    To check if a point set is a $(t,m,d)$-net, you can use the function `istmsnet` defined in the [tests](https://github.com/SciML/QuasiMonteCarlo.jl/blob/2dce9905e564a85e1280115cc8af071674fc7d80/test/runtests.jl#L34) of this package. 
+    To check if a point set is a $(t,m,d)$-net, you can use the function `istmsnet` defined in the [tests](https://github.com/SciML/QuasiMonteCarlo.jl/blob/2dce9905e564a85e1280115cc8af071674fc7d80/test/runtests.jl#L34) of this package.
     It uses the excellent [IntervalArithmetic.jl](https://github.com/JuliaIntervals/IntervalArithmetic.jl) package.

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -1,13 +1,14 @@
+
 # [Randomization methods](@id Randomization)
 
-Most of the methods presented in [Sampler](@ref Samplers) are deterministic i.e. `X = sample(n, d, ::DeterministicSamplingAlgorithm)` will always produce the same sequence $X = (X_1, \dots, X_n)$.
+Most of the methods presented in [Sampler](@ref Samplers) are deterministic, i.e. `X = sample(n, d, ::DeterministicSamplingAlgorithm)` will always produce the same sequence $X = (X_1, \dots, X_n)$.
 
 The main issue with deterministic Quasi Monte Carlo sampling is that it does not allow easy error estimation as opposed to plain Monte Carlo where the variance can be estimated.
 
 A Randomized Quasi Monte Carlo method must respect the two following criteria:
 
 1. Have $X_i\sim \mathbb{U}([0,1]^d)$ for each $i\in \{1,\cdots, n\}$.
-2. Preserve the QMC properties i.e. the randomized $X$ still has low discrepancy.
+2. Preserve the QMC properties, i.e. the randomized $X$ still has low discrepancy.
 
 This randomized version is unbiased and can be used to obtain confidence interval or to do sensitivity analysis.
 
@@ -34,7 +35,7 @@ The default method of `DeterministicSamplingAlgorithm` is `NoRand`
 NoRand
 ```
 
-To obtain multiple independent randomization of a sequence i.e. Design Matrices, look at the [Design Matrices section](@ref DesignMatrices).
+To obtain multiple independent randomization of a sequence, i.e. Design Matrices, look at the [Design Matrices section](@ref DesignMatrices).
 
 ## Scrambling methods
 
@@ -46,7 +47,7 @@ abstract type ScrambleMethod <: RandomizationMethod end
 ScrambleMethod
 ```
 
-`ScramblingMethods(b, pad, rng)` are well suited for $(t,m,d)$-nets in base $b$. `b` is the base used to scramble and `pad` the number of bits in `b`-ary decomposition i.e. $y \simeq \sum_{k=1}^{\texttt{pad}} y_k/\texttt{b}^k$.
+`ScramblingMethods(b, pad, rng)` are well suited for $(t,m,d)$-nets in base $b$. `b` is the base used to scramble and `pad` the number of bits in `b`-ary decomposition, i.e. $y \simeq \sum_{k=1}^{\texttt{pad}} y_k/\texttt{b}^k$.
 
 The `pad` is generally chosen as $\gtrsim \log_b(n)$.
 
@@ -63,13 +64,13 @@ The implemented `ScramblingMethods` are
 DigitalShift
 ```
 
-- `MatousekScramble` a.k.a Linear Matrix Scramble is what people use in practice. Indeed, the observed performances are similar to `OwenScramble` for a lesser numerical cost.
+- `MatousekScramble` a.k.a. Linear Matrix Scramble is what people use in practice. Indeed, the observed performances are similar to `OwenScramble` for a lesser numerical cost.
 
 ```@docs
 MatousekScramble
 ```
 
-- `OwenScramble` a.k.a Nested Uniform Scramble is the most understood theoretically but is more costly to operate.
+- `OwenScramble` a.k.a. Nested Uniform Scramble is the most understood theoretically but is more costly to operate.
 
 ```@docs
 OwenScramble

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -1,63 +1,87 @@
 # Randomization methods
 
-Most of the methods presented in [sampler.jl Samplers](@ref) are deterministic i.e. `sample(n, d, Sampler()::DeterministicSamplingAlgorithm)` always produces the same sequence $X = (X_1, \dots, X_n)$.
+Most of the methods presented in [Sampler](@ref Samplers) are deterministic i.e. `X = sample(n, d, Sampler()::DeterministicSamplingAlgorithm)` always produces the same sequence $X = (X_1, \dots, X_n)$.
 
 The main issue with deterministic Quasi Monte Carlo sampling is that it does not allow easy error estimation as opposed to plain Monte Carlo where the variance can be estimated.
 
-A Randomized Quasi Monte Carlo method must respect the two following criteria
+A Randomized Quasi Monte Carlo method must respect the two following criteria:
 
 1. Have $X_i\sim \mathbb{U}([0,1]^d)$ for each $i\in \{1,\cdots, n\}$.
-2. Preserve the QMC (low discrepancy) properties of $X$.
+2. Preserve the QMC properties i.e. the randomized $X$ still has low discrepancy.
 
-This randomized version can be used to obtain confidence interval or sensitivity analysis for example.
+This randomized version is unbiased and can be used to obtain confidence interval or to do sensitivity analysis.
+
+A good reference is the [book by A. Owen](https://artowen.su.domains/mc/qmcstuff.pdf), especially the Chapters 15, 16 and 17.
 
 ## API
 
-To randomize one can directly use a sampling algorithm with a randomization method as `sample(n, d, DeterministicSamplingAlgorim(R = RandomizationMethod()))` or `sample(n, lb, up, DeterministicSamplingAlgorim(R = RandomizationMethod()))`.
+There are two ways to obtain a randomized sequence:
 
-Randomization methods can also be used independently, that is, given a matrix $X$ ($d\times n$) of $n$ points in dimension $d$ in $[0,1]^d$ one can directly randomize it using `randomize(x, ::RandomizationMethod())`
+- Either directly use `QuasiMonteCarlo.sample(n, d, DeterministicSamplingAlgorithm(R = RandomizationMethod()))` or `sample(n, lb, up, DeterministicSamplingAlgorithm(R = RandomizationMethod()))`.
+- Or, given $n$ points $d$-dimensional points, all in $[0,1]^d$ one can do `randomize(X, ::RandomizationMethod())` where $X$ is a $d\times n$-matrix.
+
 ```@docs
 randomize
 ```
 
-## Scrambling methods 
+## Scrambling methods
 
-`ScramblingMethods(base, pad, rng)` are well suited for $(t,m,d)$-nets. `base` is the base used to scramble and `pad` the number of bits in `b`-ary decomposition i.e. $y \simeq \sum_{k=1}^{\texttt{pad}} y_k/\texttt{base}^k $.
-`pad` is generally chosen as $\gtrsim \log_b(n)$.
+<!-- TODO add ref in doc and dosstrings -->
+
+`ScramblingMethods(b, pad, rng)` are well suited for $(t,m,d)$-nets in base $b$. `b` is the base used to scramble and `pad` the number of bits in `b`-ary decomposition i.e. $y \simeq \sum_{k=1}^{\texttt{pad}} y_k/\texttt{b}^k$.
+
+The `pad` is generally chosen as $\gtrsim \log_b(n)$.
+
+!!! warning
+    In principle, the base `b` used for the scrambling method `ScramblingMethods(b, pad, rng)` can be an arbitrary integer, however to preserve discrepancy properties, it must match the base of the sequence to scramble.
+
+    For example, (deterministic) Sobol' sequence are base $b=2$, $(t,m,d)$ sequences while (deterministic) Faure sequences are $(t,m,d)$ sequences in prime base i.e. $b$ is a prime number.
+
 The implemented `ScramblingMethods` are
-  - `DigitalShift` the simplest and faster method. For a point $x\in [0,1]^d$ it does $y_k = (x_k + U_k) \mod b$ where $U_k ∼ \mathbb{U}(\{0, \cdots, b-1\})$
-  ```@docs
-  DigitalShift
-  ```
-  - `MatousekScramble` a.k.a Linear Matrix Scramble is what people use in practice. Indeed, the observed performances are similar to `OwenScramble` for a lesser numerical cost.
-    ```@docs
-    MatousekScramble
-    ```
-  - `OwenScramble` a.k.a Nested Uniform Scramble is the most understood theoretically but is more costly to operate.
-    ```@docs
-    OwenScramble
-    ```
-    s
+
+- `DigitalShift` the simplest and faster method. For a point $x\in [0,1]^d$ it does $y_k = (x_k + U_k) \mod b$ where $U_k \sim \mathbb{U}(\{0, \cdots, b-1\})$
+
+```@docs
+DigitalShift
+```
+
+- `MatousekScramble` a.k.a Linear Matrix Scramble is what people use in practice. Indeed, the observed performances are similar to `OwenScramble` for a lesser numerical cost.
+
+```@docs
+MatousekScramble
+```
+
+- `OwenScramble` a.k.a Nested Uniform Scramble is the most understood theoretically but is more costly to operate.
+
+```@docs
+OwenScramble
+```
+
 ## Other methods
 
-`Shift(rng)` a.k.a. Cranley Patterson Rotation. It is by far the fastest method, it is used in `LatticeRuleScramble` for example.
+`Shift(rng)` a.k.a. Cranley-Patterson Rotation. It is by far the fastest method, it is used in `LatticeRuleScramble` for example.
+
 ```@docs
-  Shift
+Shift
 ```
 
 ## Design Matrices
 
 For numerous independent randomization, use `generate_design_matrices(n, d, ::DeterministicSamplingAlgorithm), ::RandomizationMethod, num_mats)` where `num_mats` is the number of independent `X` generated.
+
 ```@docs
-  generate_design_matrices
+generate_design_matrices
 ```
 
 ## Example
 
 Randomization of a Faure sequence with various methods.
 
-```julia
-using QuasiMonteCarlo
+### Generation
+
+```@example 1
+using QuasiMonteCarlo, Random
+Random.seed!(1234)
 m = 4
 d = 3
 b = QuasiMonteCarlo.nextprime(d)
@@ -68,29 +92,29 @@ pad = m # Can also choose something as `2m` to get "better" randomization
 x_faure = QuasiMonteCarlo.sample(N, d, FaureSample())
 
 # Randomized version
+x_uniform = rand(d, N) # plain i.i.d. uniform
+x_shift = randomize(x_faure, Shift())
 x_nus = randomize(x_faure, OwenScramble(base = b, pad = pad)) # equivalent to sample(N, d, FaureSample(R = OwenScramble(base = b, pad = pad)))
 x_lms = randomize(x_faure, MatousekScramble(base = b, pad = pad))
 x_digital_shift = randomize(x_faure, DigitalShift(base = b, pad = pad))
-x_shift = randomize(x_faure, Shift())
-x_uniform = rand(d, N) # plain i.i.d. uniform
 ```
 
-```julia
-using Plots
-# Setting I like for plotting
-default(fontfamily="Computer Modern", linewidth=1, label=nothing, grid=true, framestyle=:default)
-```
+### Visualization of different methods
 
 Plot the resulting sequences along dimensions `1` and `3`.
 
-```julia
+```@example 1
+using Plots
+# Setting I like for plotting
+default(fontfamily="Computer Modern", linewidth=1, label=nothing, grid=true, framestyle=:default)
+
 d1 = 1
 d2 = 3 # you can try every combination of dimension (d1, d2)
 sequences = [x_uniform, x_faure, x_shift, x_digital_shift, x_lms, x_nus]
 names = ["Uniform", "Faure (deterministic)", "Shift", "Digital Shift", "Matousek Scramble", "Owen Scramble"]
 p = [plot(thickness_scaling=1.5, aspect_ratio=:equal) for i in sequences]
 for (i, x) in enumerate(sequences)
-    scatter!(p[i], x[d1, :], x[d2, :], ms=0.9, c=1, grid=false)
+    scatter!(p[i], x[d1, :], x[d2, :], ms=1.5, c=1, grid=false)
     title!(names[i])
     xlims!(p[i], (0, 1))
     ylims!(p[i], (0, 1))
@@ -101,35 +125,33 @@ for (i, x) in enumerate(sequences)
     hline!(p[i], range(0, 1, step=1 / 2), c=:gray, alpha=0.8)
     vline!(p[i], range(0, 1, step=1 / 2), c=:gray, alpha=0.8)
 end
-plot(p..., size=(1500, 900))
+plot(p..., size=(800, 600))
 ```
 
-![Different randomize methods of the same initial set of points](../../img/various_randomization.svg)
+### $(t,m,d)$-net visualization
 
-Faure nets and scrambled versions of Faure nets are digital $(t,m,d)$-net ([see this nice book by A. Owen](https://artowen.su.domains/mc/qmcstuff.pdf)). It basically means that they have strong equipartition properties.
-Here we can (visually) verify that with Nested Uniform Scrambling (it also works with Linear Matrix Scrambling and Digital Shift).
+<!-- TODO add precise ref for this kind of plot + `istms` net function + post into the pkg to say we are using -->
+
+Faure nets and scrambled versions of Faure nets are still digital $(t,m,d)$-net, it means that they have strong equipartition properties.
+On the following plot, we can (visually) verify that with Nested Uniform Scrambling (it also works with Linear Matrix Scrambling and Digital Shift).
 You must see one point per rectangle of volume $1/b^m$. Points on the "left" border of rectangles are included while those on the "right" are excluded.
 
-```julia
-begin
-    d1 = 1 
-    d2 = 3 # you can try every combination of dimension (d1, d2)
-    x = x_nus # Owen Scramble, you can try x_lms and x_digital_shift
-    p = [plot(thickness_scaling=1.5, aspect_ratio=:equal) for i in 0:m]
-    for i in 0:m
-        j = m - i
-        xᵢ = range(0, 1, step=1 / b^(i))
-        xⱼ = range(0, 1, step=1 / b^(j))
-        scatter!(p[i+1], x[d1, :], x[d2, :], ms=2, c=1, grid=false)
-        xlims!(p[i+1], (0, 1.01))
-        ylims!(p[i+1], (0, 1.01))
-        yticks!(p[i+1], [0, 1])
-        xticks!(p[i+1], [0, 1])
-        hline!(p[i+1], xᵢ, c=:gray, alpha=0.2)
-        vline!(p[i+1], xⱼ, c=:gray, alpha=0.2)
-    end
-    plot(p..., size=(1500, 900))
+```@example 1
+d1 = 1 
+d2 = 3 # you can try every combination of dimension (d1, d2)
+x = x_nus # Owen Scramble, you can try x_lms and x_digital_shift
+p = [plot(thickness_scaling=1.5, aspect_ratio=:equal) for i in 0:m]
+for i in 0:m
+    j = m - i
+    xᵢ = range(0, 1, step=1 / b^(i))
+    xⱼ = range(0, 1, step=1 / b^(j))
+    scatter!(p[i+1], x[d1, :], x[d2, :], ms=1.5, c=1, grid=false)
+    xlims!(p[i+1], (0, 1.01))
+    ylims!(p[i+1], (0, 1.01))
+    yticks!(p[i+1], [0, 1])
+    xticks!(p[i+1], [0, 1])
+    hline!(p[i+1], xᵢ, c=:gray, alpha=0.2)
+    vline!(p[i+1], xⱼ, c=:gray, alpha=0.2)
 end
+plot(p..., size=(800, 600))
 ```
-
-![All the different elementary rectangle contain only one points](../../img/equidistribution.svg)

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -34,6 +34,8 @@ The default method of `DeterministicSamplingAlgorithm` is `NoRand`
 NoRand
 ```
 
+To obtain multiple independent randomization of a sequence i.e. Design Matrices, look at the [Design Matrices section](@ref DesignMatrices).
+
 ## Scrambling methods
 
 ```julia
@@ -163,5 +165,5 @@ plot(p..., size=(800, 600))
 ```
 
 !!! note
-    To check if a point set is a $(t,m,d)$-net, you can use the function `istmsnet` defined in the [tests](https://github.com/SciML/QuasiMonteCarlo.jl/blob/2dce9905e564a85e1280115cc8af071674fc7d80/test/runtests.jl#L34) of this package.
+    To check if a point set is a $(t,m,d)$-net, you can use the function `istmsnet` defined in the [tests file](https://github.com/SciML/QuasiMonteCarlo.jl/blob/2dce9905e564a85e1280115cc8af071674fc7d80/test/runtests.jl#L34) of this package.
     It uses the excellent [IntervalArithmetic.jl](https://github.com/JuliaIntervals/IntervalArithmetic.jl) package.

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -1,8 +1,8 @@
 # Randomization methods
 
-Most of the methods presented in [Sampler](@ref Samplers) are deterministic i.e. `X = sample(n, d, Sampler()::DeterministicSamplingAlgorithm)` always produces the same sequence $X = (X_1, \dots, X_n)$.
+Most of the methods presented in [Sampler](@ref Samplers) are deterministic i.e. `X = sample(n, d, ::DeterministicSamplingAlgorithm)` will always produce the same sequence $X = (X_1, \dots, X_n)$.
 
-The main issue with deterministic Quasi Monte Carlo sampling is that it does not allow easy error estimation as opposed to plain Monte Carlo where the variance can be estimated.
+The main issue with deterministic Quasi Monte Carlo sampling is that it does not allow easy error estimation as opposed to plain Monte Carlo where the variance can be estimated. 
 
 A Randomized Quasi Monte Carlo method must respect the two following criteria:
 
@@ -24,9 +24,17 @@ There are two ways to obtain a randomized sequence:
 randomize
 ```
 
+The default method of `DeterministicSamplingAlgorithm` is `NoRand`
+
+```@docs
+NoRand
+```
+
 ## Scrambling methods
 
-<!-- TODO add ref in doc and dosstrings -->
+```@docs
+ScrambleMethod
+```
 
 `ScramblingMethods(b, pad, rng)` are well suited for $(t,m,d)$-nets in base $b$. `b` is the base used to scramble and `pad` the number of bits in `b`-ary decomposition i.e. $y \simeq \sum_{k=1}^{\texttt{pad}} y_k/\texttt{b}^k$.
 
@@ -129,8 +137,6 @@ plot(p..., size=(800, 600))
 ```
 
 ### $(t,m,d)$-net visualization
-
-<!-- TODO post into the pkg to say we are using -->
 
 Faure nets and its scrambled versions are digital $(t,m,d)$-net, it means that they have strong equipartition properties.
 On the following plot, we can (visually) verify that with Nested Uniform Scrambling, it also works with Linear Matrix Scrambling and Digital Shift.

--- a/docs/src/samplers.md
+++ b/docs/src/samplers.md
@@ -3,7 +3,7 @@
 ## Sample
 
 ```@docs
-sample
+QuasiMonteCarlo.sample
 ```
 
 ## Samplers
@@ -31,6 +31,5 @@ KroneckerSample
 ### Random Sampling Algorithm
 
 ```@docs
-UniformSample
 LatinHypercubeSample
 ```

--- a/docs/src/samplers.md
+++ b/docs/src/samplers.md
@@ -18,7 +18,7 @@ abstract type DeterministicSamplingAlgorithm <: SamplingAlgorithm end
 
 ### Deterministic Sampling Algorithm
 
-All `DeterministicSamplingAlgorithm` have `NoRand()` as their default `RandomizationMethod`, see [Randomization methods](@ref Randomization) section.
+All `DeterministicSamplingAlgorithm` have `NoRand()` as their default `RandomizationMethod`, see [Randomization methods](@ref Randomization) and [Design Matrices section](@ref DesignMatrices) for more information on randomization.
 
 ```@docs
 GridSample

--- a/docs/src/samplers.md
+++ b/docs/src/samplers.md
@@ -18,6 +18,8 @@ abstract type DeterministicSamplingAlgorithm <: SamplingAlgorithm end
 
 ### Deterministic Sampling Algorithm
 
+All `DeterministicSamplingAlgorithm` have `NoRand()` as their default `RandomizationMethod`, see [Randomization methods](@ref Randomization) section.
+
 ```@docs
 GridSample
 SobolSample

--- a/docs/src/samplers.md
+++ b/docs/src/samplers.md
@@ -9,6 +9,7 @@ sample
 ## Samplers
 
 Samplers are divided into two subtypes
+
 ```julia
 abstract type SamplingAlgorithm end
 abstract type RandomSamplingAlgorithm <: SamplingAlgorithm end
@@ -20,6 +21,7 @@ abstract type DeterministicSamplingAlgorithm <: SamplingAlgorithm end
 ```@docs
 GridSample
 SobolSample
+FaureSample
 LatticeRuleSample
 HaltonSample
 GoldenSample
@@ -31,5 +33,4 @@ KroneckerSample
 ```@docs
 UniformSample
 LatinHypercubeSample
-<!-- SectionSample -->
 ```

--- a/docs/src/samplers.md
+++ b/docs/src/samplers.md
@@ -22,7 +22,16 @@ All `DeterministicSamplingAlgorithm` have `NoRand()` as their default `Randomiza
 
 ```@docs
 GridSample
+```
+
+```@docs
 SobolSample
+```
+
+!!! warning
+    The QuasiMonteCarlo.jl package relies on the [Sobol.jl](https://github.com/JuliaMath/Sobol.jl) package to sample Sobol nets. The choice, there is to NOT start the sequence at `0`. This is debatable, see this [issue](https://github.com/JuliaMath/Sobol.jl/issues/31#issuecomment-1528136486) and ref therein for more context.
+
+```@docs
 FaureSample
 LatticeRuleSample
 HaltonSample

--- a/src/Faure.jl
+++ b/src/Faure.jl
@@ -20,7 +20,7 @@ end
 end
 
 """
-    FaureSample(R::RandomizationMethod)
+    FaureSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
 A Faure low-discrepancy sequence.
 

--- a/src/Faure.jl
+++ b/src/Faure.jl
@@ -37,7 +37,7 @@ The Faure sequence in dimension `s` forms a `(0, s)`-sequence with base `b = nex
 A Faure sequence must have length `k * base^s` with `k < base < 1`.
 
 References:
-Faure, H. (1982). Discrepance de suites associees a un systeme de numeration (en dimension s). *Acta Arith.*, 41, 337-351.
+Faure, H. (1982). Discrepance de suites associées a un systeme de numération (en dimension s). *Acta Arith.*, 41, 337-351.
 Owen, A. B. (1997). Monte Carlo variance of scrambled net quadrature. *SIAM Journal on Numerical Analysis*, 34(5), 1884-1910.
 """
 Base.@kwdef struct FaureSample <: DeterministicSamplingAlgorithm

--- a/src/Faure.jl
+++ b/src/Faure.jl
@@ -37,7 +37,7 @@ The Faure sequence in dimension `s` forms a `(0, s)`-sequence with base `b = nex
 A Faure sequence must have length `k * base^s` with `k < base < 1`.
 
 References:
-Faure, H. (1982). Discrepance de suites associées a un systeme de numération (en dimension s). *Acta Arith.*, 41, 337-351.
+Faure, H. (1982). Discrépance de suites associées à un système de numération (en dimension s). *Acta Arith.*, 41, 337-351.
 Owen, A. B. (1997). Monte Carlo variance of scrambled net quadrature. *SIAM Journal on Numerical Analysis*, 34(5), 1884-1910.
 """
 Base.@kwdef struct FaureSample <: DeterministicSamplingAlgorithm

--- a/src/Halton.jl
+++ b/src/Halton.jl
@@ -1,5 +1,5 @@
 """
-    HaltonSample()
+    HaltonSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
 Create a Halton sequence.
 """

--- a/src/Kronecker.jl
+++ b/src/Kronecker.jl
@@ -1,5 +1,5 @@
 """
-    KroneckerSample(generator::AbstractVector) <: DeterministicSamplingAlgorithm
+    KroneckerSample(generator::AbstractVector, R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
 A Kronecker sequence is a point set generated using a vector and equation:
 `x[i] = i * generator .% 1`

--- a/src/LatinHypercube.jl
+++ b/src/LatinHypercube.jl
@@ -1,5 +1,5 @@
 """
-    LatinHypercubeSample <: RandomSamplingAlgorithm
+    LatinHypercubeSample(rng::AbstractRNG = Random.GLOBAL_RNG) <: RandomSamplingAlgorithm
 
 A Latin Hypercube is a point set with the property that every one-dimensional interval `(i/n, i+1/n)` contains exactly one point. This is a good way to sample a high-dimensional space, as it is more uniform than a random sample but does not require as many points as a full net.
 """

--- a/src/Lattices.jl
+++ b/src/Lattices.jl
@@ -1,5 +1,5 @@
 """
-    GridSample()
+    GridSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
 A simple rectangular grid lattice.
 
@@ -17,7 +17,7 @@ function sample(n::Integer, d::Integer, S::GridSample, T = Float64)
 end
 
 """
-    LatticeRuleSample()
+    LatticeRuleSample() <: DeterministicSamplingAlgorithm
 
 Generate a point set using a lattice rule.
 """

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -45,19 +45,23 @@ function sample(n::Integer, d::Integer, S::RandomSample, T = Float64)
 end
 
 """
-    sample(n, lb, ub, sample_method)
-    sample(n, d, sample_method)
+```julia
+sample(n::Integer, d::Integer, S::SamplingAlgorithm, T = Float64)
+sample(n::Integer, lb::T, ub::T, S::SamplingAlgorithm) where T <: Union{Base.AbstractVecOrTuple, Number}
+```
 
-Create a QMC point set, where:
+Return a QMC point set where:
 - `n` is the number of points to sample.
-- `lb` is the lower bound for each variable. The length determines the dimensionality.
-- `ub` is the upper bound.
-- `d` is the dimensionality of the point set.
-- `sample_method` is the quasi-Monte Carlo sampling strategy. Note that any Distributions.jl
-  distribution can be used in addition to any `SamplingAlgorithm`.
+- `S` is the quasi-Monte Carlo sampling strategy. 
+The point set is in a `d`-dimensional unit box `[0, 1]^d`. 
+If the bounds are specified, the sample is transformed (translation + scaling) into a box `[lb, ub]` where:
+- `lb` is the lower bound for each variable. Its length fixes the dimensionality of the sample.
+- `ub` is the upper bound. Its dimension must match `length(lb)`.
+
+In the first method the type of the point set is specified by `T` while in the second method the output type is infered from the bound types.
 """
 function sample(n::Integer, lb::T, ub::T,
-                S::D) where {T <: Union{Base.AbstractVecOrTuple, Number}, D <: Union{SamplingAlgorithm, Distributions.Sampleable}}
+    S::D) where {T <: Union{Base.AbstractVecOrTuple, Number}, D <: Union{SamplingAlgorithm, Distributions.Sampleable}}
     _check_sequence(lb, ub, n)
     lb = float.(lb)
     ub = float.(ub)
@@ -66,9 +70,18 @@ function sample(n::Integer, lb::T, ub::T,
 end
 
 """
-    sample(n, d, D::Distribution)
+```julia
+sample(n::Integer, lb::T, ub::T, D::Distributions.Sampleable, T = eltype(D))
+sample(n::Integer, lb::T, ub::T, D::Distributions.Sampleable) where T <: Union{Base.AbstractVecOrTuple, Number}
+```
 
-Returns a tuple containing independent random samples from distribution `D`.
+Return a point set from a distribution `D`:
+- `n` is the number of points to sample.
+- `D` is a `Distributions.Sampleable` from Distributions.jl.
+The point set is in a `d`-dimensional unit box `[0, 1]^d`. 
+If the bounds are specified, the sample is transformed (translation + scaling) into a box `[lb, ub]` where:
+- `lb` is the lower bound for each variable. Its length fixes the dimensionality of the sample.
+- `ub` is the upper bound. Its dimension must match `length(lb)`.
 """
 function sample(n::Integer, d::Integer, D::Distributions.Sampleable, T = eltype(D))
     @assert n>0 ZERO_SAMPLES_MESSAGE

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -69,7 +69,7 @@ Return a point set from a distribution `D`:
 - `n` is the number of points to sample.
 - `D` is a `Distributions.Sampleable` from Distributions.jl.
 The point set is in a `d`-dimensional unit box `[0, 1]^d`. 
-If the bounds are specified, the sample is transformed (translation + scaling) into a box `[lb, ub]` where:
+If the bounds are specified instead of just `d`, the sample is transformed (translation + scaling) into a box `[lb, ub]` where:
 - `lb` is the lower bound for each variable. Its length fixes the dimensionality of the sample.
 - `ub` is the upper bound. Its dimension must match `length(lb)`.
 """
@@ -100,7 +100,7 @@ Create `num_mats` matrices each containing a QMC point set, where:
 - `d` is the dimensionality of the point set in `[0, 1)ᵈ`,
 - `sample_method` is the quasi-Monte Carlo sampling strategy used to create a deterministic point set `out`.
 - `T` is the `eltype` of the point sets. For some QMC methods (Faure, Sobol) this can be `Rational`
-If the bound `lb` and `ub` are specified, the sampled will be in the box `[lb, ub]`.
+If the bound `lb` and `ub` are specified instead of `d`, the samples will be transformed into the box `[lb, ub]`.
 """
 function generate_design_matrices(n, d, sampler::DeterministicSamplingAlgorithm, num_mats,
                                   T = Float64)
@@ -152,7 +152,8 @@ randomize(x, S::NoRand) = x
 """
     generate_design_matrices(n, d, sampler, R::NoRand, num_mats, T = Float64)
 `R = NoRand()` produces `num_mats` matrices each containing a different deterministic point set in `[0, 1)ᵈ`.
-Note that this is an ad hoc way to produce different `generate_design_matrices` as it creates a deterministic point in dimension `d × num_mats` and split it in `num_mats` point set of dimension `d` which have no QMC garantuees.
+Note that this is an ad hoc way to produce i.i.d sequence as it creates a deterministic point in dimension `d × num_mats` and split it in `num_mats` point set of dimension `d`. 
+This does not have any QMC garantuees.
 """
 function generate_design_matrices(n, d, sampler, R::NoRand, num_mats, T = Float64)
     out = sample(n, num_mats * d, sampler, T)

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -51,7 +51,8 @@ If the bounds are specified, the sample is transformed (translation + scaling) i
 In the first method the type of the point set is specified by `T` while in the second method the output type is infered from the bound types.
 """
 function sample(n::Integer, lb::T, ub::T,
-    S::D) where {T <: Union{Base.AbstractVecOrTuple, Number}, D <: Union{SamplingAlgorithm, Distributions.Sampleable}}
+                S::D) where {T <: Union{Base.AbstractVecOrTuple, Number},
+                             D <: Union{SamplingAlgorithm, Distributions.Sampleable}}
     _check_sequence(lb, ub, n)
     lb = float.(lb)
     ub = float.(ub)

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -57,7 +57,7 @@ Create a QMC point set, where:
   distribution can be used in addition to any `SamplingAlgorithm`.
 """
 function sample(n::Integer, lb::T, ub::T,
-                S::SamplingAlgorithm) where {T <: Union{Base.AbstractVecOrTuple, Number}}
+                S::D) where {T <: Union{Base.AbstractVecOrTuple, Number}, D <: Union{SamplingAlgorithm, Distributions.Sampleable}}
     _check_sequence(lb, ub, n)
     lb = float.(lb)
     ub = float.(ub)
@@ -70,7 +70,7 @@ end
 
 Returns a tuple containing independent random samples from distribution `D`.
 """
-function sample(n::Integer, d::Integer, D::Distributions.Sampleable)
+function sample(n::Integer, d::Integer, D::Distributions.Sampleable, T = eltype(D))
     @assert n>0 ZERO_SAMPLES_MESSAGE
     x = [[rand(D) for j in 1:d] for i in 1:n]
     return reduce(hcat, x)

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -86,30 +86,32 @@ function logi(b::Int, n::Int)
     return m
 end
 
-include("net_utilities.jl")
-include("VanDerCorput.jl")
-include("Faure.jl")
-include("Kronecker.jl")
-include("Halton.jl")
-include("Sobol.jl")
-include("LatinHypercube.jl")
-include("Lattices.jl")
-include("Section.jl")
-
 """
 ```julia
-generate_design_matrices(n, lb, ub, sample_method, num_mats)
+generate_design_matrices(n, d, sample_method::DeterministicSamplingAlgorithm,
+num_mats, T = Float64)
+generate_design_matrices(n, d, sample_method::RandomSamplingAlgorithm,
+num_mats, T = Float64)
+generate_design_matrices(n, lb, ub, sample_method,
+num_mats = 2)
 ```
-
 Create `num_mats` matrices each containing a QMC point set, where:
 - `n` is the number of points to sample.
-- `lb` is the lower bound for each variable. The length determines the dimensionality.
-- `ub` is the upper bound.
-- `d` is the dimensionality of the point set.
-- `sample_method` is the quasi-Monte Carlo sampling strategy. Note that any Distributions.jl
-  distribution can be used in addition to any `SamplingAlgorithm`.
-- You can specify a `RandomizationMethod` for `sample_method<:DeterministicSamplingAlgorithm`
+- `d` is the dimensionality of the point set in `[0, 1)ᵈ`,
+- `sample_method` is the quasi-Monte Carlo sampling strategy used to create a deterministic point set `out`.
+- `T` is the `eltype` of the point sets. For some QMC methods (Faure, Sobol) this can be `Rational`
+If the bound `lb` and `ub` are specified, the sampled will be in the box `[lb, ub]`.
 """
+function generate_design_matrices(n, d, sampler::DeterministicSamplingAlgorithm, num_mats,
+                                  T = Float64)
+    return generate_design_matrices(n, d, sampler, sampler.R, num_mats, T)
+end
+
+function generate_design_matrices(n, d, sampler::RandomSamplingAlgorithm, num_mats,
+                                  T = Float64)
+    return [sample(n, d, sampler, T) for j in 1:num_mats]
+end
+
 function generate_design_matrices(n, lb, ub, sampler,
                                   num_mats = 2)
     if n <= 0
@@ -127,15 +129,15 @@ function generate_design_matrices(n, lb, ub, sampler,
     return out
 end
 
-function generate_design_matrices(n, d, sampler::DeterministicSamplingAlgorithm, num_mats,
-                                  T = Float64)
-    return generate_design_matrices(n, d, sampler, sampler.R, num_mats, T)
-end
-
-function generate_design_matrices(n, d, sampler::RandomSamplingAlgorithm, num_mats,
-                                  T = Float64)
-    return [sample(n, d, sampler, T) for j in 1:num_mats]
-end
+include("net_utilities.jl")
+include("VanDerCorput.jl")
+include("Faure.jl")
+include("Kronecker.jl")
+include("Halton.jl")
+include("Sobol.jl")
+include("LatinHypercube.jl")
+include("Lattices.jl")
+include("Section.jl")
 
 """
 ```julia

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -8,16 +8,6 @@ abstract type RandomSamplingAlgorithm <: SamplingAlgorithm end
 abstract type DeterministicSamplingAlgorithm <: SamplingAlgorithm end
 abstract type RandomizationMethod end
 
-include("net_utilities.jl")
-include("VanDerCorput.jl")
-include("Faure.jl")
-include("Kronecker.jl")
-include("Halton.jl")
-include("Sobol.jl")
-include("LatinHypercube.jl")
-include("Lattices.jl")
-include("Section.jl")
-
 const UB_LB_MESSAGE = "Lower bound exceeds upper bound (lb > ub)"
 const ZERO_SAMPLES_MESSAGE = "Number of samples must be greater than zero"
 const DIM_MISMATCH_MESSAGE = "Dimensionality of lb and ub must match"
@@ -95,6 +85,16 @@ function logi(b::Int, n::Int)
     b^m == n || throw(ArgumentError("$n is not a power of $b"))
     return m
 end
+
+include("net_utilities.jl")
+include("VanDerCorput.jl")
+include("Faure.jl")
+include("Kronecker.jl")
+include("Halton.jl")
+include("Sobol.jl")
+include("LatinHypercube.jl")
+include("Lattices.jl")
+include("Section.jl")
 
 """
 ```julia

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -123,9 +123,10 @@ function generate_design_matrices(n, d, sampler::RandomSamplingAlgorithm, num_ma
                                   T = Float64)
     return [sample(n, d, sampler, T) for j in 1:num_mats]
 end
+
 """
 ```julia
-NoRand
+NoRand <: RandomizationMethod
 ```
 
 No Randomization is performed on the sampled sequence.
@@ -148,7 +149,6 @@ include("RandomizedQuasiMonteCarlo/scrambling_base_b.jl")
 
 export SamplingAlgorithm,
        GridSample,
-       UniformSample,
        SobolSample,
        LatinHypercubeSample,
        LatticeRuleSample,

--- a/src/RandomizedQuasiMonteCarlo/scrambling_base_b.jl
+++ b/src/RandomizedQuasiMonteCarlo/scrambling_base_b.jl
@@ -1,9 +1,10 @@
 # * The scrambling codes were first inspired from Owen's `R` implementation that can be found [here](https://artowen.su.domains/code/rsobol.R). * #
 
 """ 
-    ```julia
-    ScrambleMethod
-    ```
+```julia
+ScrambleMethod <: RandomizationMethod
+```
+
 A scramble method needs at lease the scrambling base `b`, the number of "bits" to use `pad` (`pad=32` is the default) and a seed `rng` (`rng = Random.GLOBAL_RNG` is the default).
 The scramble methods implementer are 
 - `DigitalShift`.
@@ -28,7 +29,7 @@ end
 
 """
 ```julia
-OwenScramble
+OwenScramble <: ScrambleMethod
 ```
 
 Nested Uniform Scramble aka Owen' scramble.
@@ -134,7 +135,7 @@ end
 
 """
 ```julia
-MatousekScramble
+MatousekScramble <: ScrambleMethod
 ```
 
 Linear Matrix Scramble aka Matousek' scramble.
@@ -215,7 +216,7 @@ getmatousek(m::Integer, b::Integer) = getmatousek(Random.GLOBAL_RNG, m, b)
 
 """
 ```julia
-DigitalShift
+DigitalShift <: ScrambleMethod
 ```
 
 Digital shift. 

--- a/src/RandomizedQuasiMonteCarlo/scrambling_base_b.jl
+++ b/src/RandomizedQuasiMonteCarlo/scrambling_base_b.jl
@@ -1,3 +1,5 @@
+# * The scrambling codes were first inspired from Owen's `R` implementation that can be found [here](https://artowen.su.domains/code/rsobol.R). * #
+
 """ 
     ```julia
     ScrambleMethod
@@ -34,6 +36,8 @@ Nested Uniform Scramble aka Owen' scramble.
 `randomize(x, R::OwenScramble)` returns a scrambled version of `x`. 
 The scramble method is Nested Uniform Scramble which was introduced in Owen (1995).
 `pad` is the number of bits used for each points. One needs `pad ≥ log(base, n)`. 
+
+References: Owen, A. B. (1995). Randomly permuted (t, m, s)-nets and (t, s)-sequences. In Monte Carlo and Quasi-Monte Carlo Methods in Scientific Computing: Proceedings of a conference at the University of Nevada, Las Vegas, Nevada, USA, June 23–25, 1994 (pp. 299-317). Springer New York.
 """
 Base.@kwdef struct OwenScramble <: ScrambleMethod
     base::Int
@@ -138,6 +142,8 @@ Linear Matrix Scramble aka Matousek' scramble.
 `randomize(x, R::MatousekScramble)` returns a scrambled version of `x`. 
 The scramble method is Linear Matrix Scramble which was introduced in Matousek (1998).
 `pad` is the number of bits used for each points. One need `pad ≥ log(base, n)`. 
+
+References: Matoušek, J. (1998). On thel2-discrepancy for anchored boxes. Journal of Complexity, 14(4), 527-556.
 """
 Base.@kwdef struct MatousekScramble <: ScrambleMethod
     base::Int

--- a/src/RandomizedQuasiMonteCarlo/shifting.jl
+++ b/src/RandomizedQuasiMonteCarlo/shifting.jl
@@ -4,6 +4,8 @@ Shifting
 ```
 
 Cranley-Patterson rotation aka Shifting
+
+References: Cranley, R., & Patterson, T. N. (1976). Randomization of number theoretic methods for multiple integration. SIAM Journal on Numerical Analysis, 13(6), 904-914.
 """
 Base.@kwdef @concrete struct Shift <: RandomizationMethod
     rng::AbstractRNG = Random.GLOBAL_RNG

--- a/src/RandomizedQuasiMonteCarlo/shifting.jl
+++ b/src/RandomizedQuasiMonteCarlo/shifting.jl
@@ -1,6 +1,6 @@
 """
 ```julia
-Shifting
+Shifting <: RandomizationMethod
 ```
 
 Cranley-Patterson rotation aka Shifting

--- a/src/RandomizedQuasiMonteCarlo/shifting.jl
+++ b/src/RandomizedQuasiMonteCarlo/shifting.jl
@@ -1,6 +1,6 @@
 """
 ```julia
-Shifting <: RandomizationMethod
+Shifting(rng::AbstractRNG = Random.GLOBAL_RNG) <: RandomizationMethod
 ```
 
 Cranley-Patterson rotation aka Shifting

--- a/src/RandomizedQuasiMonteCarlo/shifting.jl
+++ b/src/RandomizedQuasiMonteCarlo/shifting.jl
@@ -46,18 +46,6 @@ end
 
 frac(y) = y - floor(y)
 
-"""
-```julia
-generate_design_matrices(n, d, sample_method::DeterministicSamplingAlgorithm,
-                         R::RandomizationMethod, num_mats, T = Float64)
-```
-Create `num_mats` matrices each containing a QMC point set in `[0, 1)ᵈ`, where:
-- `n` is the number of points to sample.
-- `d` is the dimensionality of the point set.
-- `sample_method` is the quasi-Monte Carlo sampling strategy used to create a deterministic point set `out`.
-- `R` is the method used to randomize `num_mats` times the point set `out`. Each randomization is i.i.d.
-- `T` is the `eltype` of the point sets. For some QMC methods (Faure, Sobol) this can be `Rational`
-"""
 function generate_design_matrices(n, d, sampler, R::Shift, num_mats, T = Float64)
     # Generate unrandomized sequence
     no_rand_sampler = @set sampler.R = NoRand()

--- a/src/RandomizedQuasiMonteCarlo/shifting.jl
+++ b/src/RandomizedQuasiMonteCarlo/shifting.jl
@@ -13,7 +13,7 @@ end
 
 """
     randomize(x, R::Shift)
-Cranley Patterson Rotation i.e. `y = (points .+ U) mod 1` where `U ∼ 𝕌([0,1]ᵈ)` and `points` is a `d×n` matrix
+Cranley Patterson Rotation i.e. `y = (x .+ U) mod 1` where `U ∼ 𝕌([0,1]ᵈ)` and `x` is a `d×n` matrix
 """
 function randomize(x, R::Shift)
     y = copy(x)

--- a/src/Sobol.jl
+++ b/src/Sobol.jl
@@ -1,5 +1,5 @@
 """
-    SobolSample <: DeterministicSamplingAlgorithm
+    SobolSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
 Samples taken from Sobol's base-2 sequence.
 """

--- a/src/VanDerCorput.jl
+++ b/src/VanDerCorput.jl
@@ -1,5 +1,5 @@
 """
-    VanDerCorputSample(base::Integer)
+    VanDerCorputSample(base::Integer, R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
 The van der Corput sequence, also called the radical inverse sequence, is a one-dimensional
 low-discrepancy sequence that recursively splits the unit interval into equally-sized
@@ -13,7 +13,7 @@ is a multiple of a power of the base.
 Base.@kwdef @concrete struct VanDerCorputSample{I <: Integer} <:
                              DeterministicSamplingAlgorithm
     base::I
-    R::RandomizationMethod = NoRa
+    R::RandomizationMethod = NoRand()
 end
 
 function sample(n::Integer, d::Integer, S::VanDerCorputSample, T::Type = Float64)


### PR DESCRIPTION
I made a few update to documentations like
- fixing docstring call of `sample`. 
- Changing a bit some docstrings to match the PR #65 rebase
- Separate in a new page generating matrix for clarity
- Add an example in home page of doc of QMC vs MC (this seems like a must-have for a QMC pkg).
- Change Project.toml of docs to use [Documenters.jl code block example ](https://documenter.juliadocs.org/stable/man/syntax/#@example-block).

I hope this help!

BTW, I believe we should remove `RandomSample` sometime called `UniformSample`. Instead, we can directly use `Uniform` in `sample`.