### PR TITLE
Add randomized halton sequence

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,6 +29,7 @@ s = QuasiMonteCarlo.sample(n, lb, ub, SobolSample())
 s = QuasiMonteCarlo.sample(n, lb, ub, LatinHypercubeSample())
 s = QuasiMonteCarlo.sample(n, lb, ub, LatticeRuleSample())
 s = QuasiMonteCarlo.sample(n, lb, ub, HaltonSample())
+s = QuasiMonteCarlo.sample(n, lb, ub, RandomizedHaltonSample())
 ```
 
 The output `s` is a matrix, so one can use things like `@uview` from

--- a/docs/src/samplers.md
+++ b/docs/src/samplers.md
@@ -44,4 +44,5 @@ KroneckerSample
 
 ```@docs
 LatinHypercubeSample
+RandomizedHaltonSample
 ```

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -55,8 +55,8 @@ Return a QMC point set where:
 In the first method the type of the point set is specified by `T` while in the second method the output type is inferred from the bound types.
 """
 function sample(n::Integer, lb::T, ub::T,
-    S::D) where {T <: Union{Base.AbstractVecOrTuple, Number},
-    D <: SamplingAlgorithm}
+        S::D) where {T <: Union{Base.AbstractVecOrTuple, Number},
+        D <: SamplingAlgorithm}
     _check_sequence(lb, ub, n)
     lb = float.(lb)
     ub = float.(ub)
@@ -78,6 +78,7 @@ include("Kronecker.jl")
 include("Halton.jl")
 include("Sobol.jl")
 include("LatinHypercube.jl")
+include("RandomizedHalton.jl")
 include("Lattices.jl")
 include("Section.jl")
 
@@ -99,6 +100,7 @@ export SamplingAlgorithm,
     GridSample,
     SobolSample,
     LatinHypercubeSample,
+    RandomizedHaltonSample,
     LatticeRuleSample,
     RandomSample,
     HaltonSample,

--- a/src/RandomizedHalton.jl
+++ b/src/RandomizedHalton.jl
@@ -1,7 +1,10 @@
 """
     RandomizedHalton(rng::AbstractRNG = Random.GLOBAL_RNG) <: RandomSamplingAlgorithm
 
-    A Halton-sequence randomized using the algorithm presented by A. Owen in "A randomized Halton algorithm in R" (2017).
+    Create a randomized Halton sequence.
+
+    References:
+    Owen, A. (2017). *A randomized Halton algorithm in R*. https://doi.org/10.48550/arXiv.1706.02808
 """
 Base.@kwdef @concrete struct RandomizedHaltonSample <: RandomSamplingAlgorithm
     rng::AbstractRNG = Random.GLOBAL_RNG
@@ -9,12 +12,12 @@ end
 
 function sample(n::Integer, d::Integer, S::RandomizedHaltonSample, T = Float64)
     _check_sequence(n)
-    rng = S.rng
     bases = nextprimes(one(n), d)
     halton_seq = Matrix{T}(undef, d, n)
 
+    ind = collect(1:n)
     for i in 1:d
-        halton_seq[i, :] = randradinv(collect(1:n), S.rng, bases[i])
+        halton_seq[i, :] = randradinv(ind, S.rng, bases[i])
     end
     return halton_seq
 end
@@ -24,9 +27,11 @@ function randradinv(ind::Vector{Int}, rng::AbstractRNG, b::Int = 2)
     ans = ind .* 0
     res = ind
 
+    base_ind = 1:b
+
     while (1 - b2r < 1)
         dig = res .% b
-        perm = shuffle(rng, collect(1:b)) .- 1
+        perm = shuffle(rng, base_ind) .- 1
         pdig = perm[convert.(Int, dig .+ 1)]
         ans = ans .+ pdig .* b2r
         b2r = b2r / b

--- a/src/RandomizedHalton.jl
+++ b/src/RandomizedHalton.jl
@@ -1,0 +1,36 @@
+"""
+    RandomizedHalton(rng::AbstractRNG = Random.GLOBAL_RNG) <: RandomSamplingAlgorithm
+
+    A Halton-sequence randomized using the algorithm presented by A. Owen in "A randomized Halton algorithm in R" (2017).
+"""
+Base.@kwdef @concrete struct RandomizedHaltonSample <: RandomSamplingAlgorithm
+    rng::AbstractRNG = Random.GLOBAL_RNG
+end
+
+function sample(n::Integer, d::Integer, S::RandomizedHaltonSample, T = Float64)
+    _check_sequence(n)
+    rng = S.rng
+    bases = nextprimes(one(n), d)
+    halton_seq = Matrix{T}(undef, d, n)
+
+    for i in 1:d
+        halton_seq[i, :] = randradinv(collect(1:n), S.rng, bases[i])
+    end
+    return halton_seq
+end
+
+function randradinv(ind::Vector{Int}, rng::AbstractRNG, b::Int = 2)
+    b2r = 1 / b
+    ans = ind .* 0
+    res = ind
+
+    while (1 - b2r < 1)
+        dig = res .% b
+        perm = shuffle(rng, collect(1:b)) .- 1
+        pdig = perm[convert.(Int, dig .+ 1)]
+        ans = ans .+ pdig .* b2r
+        b2r = b2r / b
+        res = (res .- dig) ./ b
+    end
+    return ans
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR adds the randomized Halton sequence algorithm as presented in *A randomized Halton algorithm in R* (Owen, 2017). Since the algorithm doesn't scramble an existing deterministic sequence but directly creates the random samples, the decision was made to implement it as a 'RandomSamplingAlgorithm'.

The algorithm is implemented in line with the pseudo code presented in the paper.

The random sequence retains all properties of the Halton sequence. Therefore, we reused the present test for the Halton sequence for the new randomized version.
