### PR TITLE
Remove Julia v1.9 get_extension compatibility code

### DIFF
--- a/ext/QuasiMonteCarloDistributionsExt.jl
+++ b/ext/QuasiMonteCarloDistributionsExt.jl
@@ -1,7 +1,7 @@
 module QuasiMonteCarloDistributionsExt
 
 using QuasiMonteCarlo
-isdefined(Base, :get_extension) ? (import Distributions) : (import ..Distributions)
+import Distributions
 
 """
 ```julia


### PR DESCRIPTION
## Description

This PR removes the compatibility checks for `isdefined(Base, :get_extension)` since all SciML packages now require Julia v1.10+, where package extensions are built-in.

## Changes

- Removed unnecessary version checks in extension loading code
- Simplified extension imports by removing conditional logic
- Cleaned up obsolete compatibility code

## Context

As identified in the SciML-wide analysis, all SciML packages have moved to requiring Julia v1.10+ as the minimum version. This makes the compatibility code for checking whether package extensions are available redundant.

The `isdefined(Base, :get_extension)` checks were used to support Julia v1.9 where extensions were loaded differently. Since we no longer support v1.9, this code can be safely removed.

## Testing

- [ ] Package tests pass locally
- [ ] No changes to functionality, only removal of version checks