### PR TITLE
Set QuasiMonteCarlo version to 0.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuasiMonteCarlo"
 uuid = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 authors = ["ludoro <ludovicobessi@gmail.com>, Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.3.12"
+version = "0.4.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| QuasiMonteCarlo | 0.3.11 | 0.3.12 | 0.4.0 | minor |

## Verification

- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total      Time / Core/core.jl  |  405    405  13m52.0s / Test Summary:      | Pass  Total  Time / Core/public_api.jl |   23     23  1.6s / Testing QuasiMonteCarlo tests passed`
- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Total     Time / QA/qa.jl      |   20     20  1m08.1s / Testing QuasiMonteCarlo tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- QuasiMonteCarlo: `@JuliaRegistrator register`