### PR TITLE
Drop [compat] majors whose successor is 2+ years old

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ SciMLPublic = "1"
 SciMLTesting = "2.4"
 Sobol = "1.5"
 Statistics = "1"
-StatsBase = "0.33, 0.34"
+StatsBase = "0.34"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` edits that **drop majors whose successor has been out for at least 2 years** (cutoff 2024-08-14). No code, tests, or package version were changed.

- `Project.toml` [extras] `StatsBase`: `0.33, 0.34` → `0.34` (drop 0.33; StatsBase 0.34.x first released 2023-05-01)

## Why

Once a newer major has been in the General registry for two years, the previous major is untested and unused. Declaring it only keeps a dead window in the resolver / downgrade graph. Remaining majors and their existing lower bounds are unchanged.

## Verification

Dates come from GitHub tags (and General registrator PRs where a tag was later rewritten). Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
