### PR TITLE
docs: specify QuasiMonteCarlo public and extension interfaces

### DIFF
--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -1,4 +1,4 @@
-# Developer API
+# [Developer API](@id DeveloperAPI)
 
 !!! warning "Developer API"
     The interfaces on this page are public and versioned for package developers
@@ -14,3 +14,38 @@ same bounds and sample-count requirements as QuasiMonteCarlo.jl.
 ```@docs
 QuasiMonteCarlo._check_sequence
 ```
+
+## Extension interfaces
+
+The following interfaces are public for package developers. They describe the
+minimum contracts used by the generic sampling and design-matrix functions.
+They are not exported, so application code should use the exported
+[`sample`](@ref), [`randomize`](@ref), [`DesignMatrix`](@ref), and
+[`generate_design_matrices`](@ref) functions instead of calling implementation
+hooks directly.
+
+```@docs
+QuasiMonteCarlo.RandomSamplingAlgorithm
+QuasiMonteCarlo.DeterministicSamplingAlgorithm
+QuasiMonteCarlo.AbstractDesignMatrix
+```
+
+### Generic contract example
+
+An extension only needs to implement the unit-box `sample` method. The bounds
+and design-matrix methods are supplied by QuasiMonteCarlo.jl:
+
+```julia
+struct CenterSampler <: QuasiMonteCarlo.SamplingAlgorithm end
+
+function QuasiMonteCarlo.sample(n::Integer, d::Integer,
+        ::CenterSampler, T = Float64)
+    return fill(convert(T, 0.5), d, n)
+end
+
+points = QuasiMonteCarlo.sample(4, [-1.0, 2.0], [1.0, 4.0], CenterSampler())
+```
+
+The implementation must return a `d`-by-`n` matrix in the unit box. It must
+not add a competing bounds method, because the generic bounds method validates
+and scales the unit-box result.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,9 @@
 # QuasiMonteCarlo.jl: Quasi-Monte Carlo (QMC) Samples Made Easy
 
+```@docs
+QuasiMonteCarlo
+```
+
 QuasiMonteCarlo.jl is a lightweight package for generating Quasi-Monte Carlo (QMC) samples
 using various different methods.
 
@@ -33,7 +37,7 @@ s = QuasiMonteCarlo.sample(n, lb, ub, RandomizedHaltonSample())
 ```
 
 The output `s` is a matrix, so one can use things like `@uview` from
-[UnsafeArrays.jl](https://github.com/oschulz/UnsafeArrays.jl) for a stack-allocated
+[UnsafeArrays.jl](https://github.com/JuliaArrays/UnsafeArrays.jl) for a stack-allocated
 view of the `i`th point:
 
 ```julia

--- a/docs/src/randomization.md
+++ b/docs/src/randomization.md
@@ -189,5 +189,7 @@ plot(p..., size = (800, 600))
 
 !!! note
     
-    To check if a point set is a $(t,m,d)$-net, you can use the function `istmsnet` defined in the [tests file](https://github.com/SciML/QuasiMonteCarlo.jl/blob/2dce9905e564a85e1280115cc8af071674fc7d80/test/runtests.jl#L34) of this package.
+    The package test suite uses the `istmsnet` helper to check whether a point
+    set is a $(t,m,d)$-net. See the test suite for the exact checks when
+    contributing a new sequence.
     It uses the excellent [IntervalArithmetic.jl](https://github.com/JuliaIntervals/IntervalArithmetic.jl) package.

--- a/docs/src/samplers.md
+++ b/docs/src/samplers.md
@@ -12,9 +12,11 @@ Samplers are divided into two subtypes
 
 ```@docs
 SamplingAlgorithm
-QuasiMonteCarlo.RandomSamplingAlgorithm
-QuasiMonteCarlo.DeterministicSamplingAlgorithm
 ```
+
+The extension contracts for `RandomSamplingAlgorithm` and
+`DeterministicSamplingAlgorithm` are documented on the [Developer API](@ref
+DeveloperAPI) page.
 
 ### Deterministic Sampling Algorithm
 

--- a/ext/QuasiMonteCarloDistributionsExt.jl
+++ b/ext/QuasiMonteCarloDistributionsExt.jl
@@ -4,22 +4,34 @@ using QuasiMonteCarlo
 import Distributions
 
 """
-```julia
-sample(n::Integer, lb::T, ub::T, D::Distributions.Sampleable, T = eltype(D))
-sample(n::Integer,
-    lb::T,
-    ub::T,
-    D::Distributions.Sampleable) where {T <: Union{AbstractVector, Tuple, Number}}
+    sample(n::Integer, d::Integer, D::Distributions.Sampleable, T = eltype(D))
+
+Draw independent samples from a `Distributions.Sampleable` distribution.
+
+# Arguments
+
+- `n::Integer`: Number of points to draw.
+- `d::Integer`: Number of independent coordinates in each point.
+- `D::Distributions.Sampleable`: Distribution sampled independently for each
+  coordinate.
+- `T = eltype(D)`: Element-type argument retained for compatibility with the
+  general `sample` interface. The distribution controls the element type of
+  the generated values.
+
+# Returns
+
+- A matrix with size `(d, n)`, with one sampled point per column.
+
+# Examples
+
+```jldoctest
+julia> using Distributions, QuasiMonteCarlo
+
+julia> points = sample(4, 2, Normal());
+
+julia> size(points)
+(2, 4)
 ```
-
-Return a point set from a distribution `D`:
-
-  - `n` is the number of points to sample.
-  - `D` is a `Distributions.Sampleable` from Distributions.jl.
-    The point set is in a `d`-dimensional unit box `[0, 1]^d`.
-    If the bounds are specified instead of just `d`, the sample is transformed (translation + scaling) into a box `[lb, ub]` where:
-  - `lb` is the lower bound for each variable. Its length fixes the dimensionality of the sample.
-  - `ub` is the upper bound. Its dimension must match `length(lb)`.
 """
 function QuasiMonteCarlo.sample(
         n::Integer,
@@ -33,24 +45,27 @@ function QuasiMonteCarlo.sample(
 end
 
 """
-```julia
-sample(n::Integer, d::Integer, S::Distributions.Sampleable, T = Float64)
-sample(n::Integer,
-    lb::T,
-    ub::T,
-    S::Distributions.Sampleable) where {T <: Union{AbstractVector, Tuple, Number}}
-```
+    sample(n::Integer, lb, ub, sampler::Distributions.Sampleable)
 
-Return a QMC point set where:
+Draw a quasi-Monte Carlo point set and map it to the box defined by `lb` and
+`ub` using a `Distributions.Sampleable` as the sampler argument.
 
-  - `n` is the number of points to sample.
-  - `S` is the quasi-Monte Carlo sampling strategy.
-    The point set is in a `d`-dimensional unit box `[0, 1]^d`.
-    If the bounds are specified, the sample is transformed (translation + scaling) into a box `[lb, ub]` where:
-  - `lb` is the lower bound for each variable. Its length fixes the dimensionality of the sample.
-  - `ub` is the upper bound. Its dimension must match `length(lb)`.
+# Arguments
 
-In the first method the type of the point set is specified by `T` while in the second method the output type is inferred from the bound types.
+- `n::Integer`: Number of points to draw.
+- `lb`: Scalar, tuple, or vector of lower bounds.
+- `ub`: Upper bounds with the same shape as `lb`.
+- `sampler::Distributions.Sampleable`: Distribution used by the extension.
+
+# Returns
+
+- A matrix with size `(length(lb), n)` whose columns lie in the requested
+  bounds.
+
+# Throws
+
+- `AssertionError`: If the bounds have different lengths or a lower bound
+  exceeds its corresponding upper bound.
 """
 function QuasiMonteCarlo.sample(
         n::Integer, lb::T, ub::T,

--- a/src/Faure.jl
+++ b/src/Faure.jl
@@ -24,7 +24,13 @@ end
 """
     FaureSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
-A Faure low-discrepancy sequence.
+A Faure low-discrepancy sequence in the prime base determined by the sample
+dimension.
+
+# Fields
+
+- `R::RandomizationMethod = NoRand()`: Randomization applied after the
+  deterministic Faure points are generated.
 
 Faure-distributed samples cover all dimensions evenly, using the same set of points for all
 variables, up to ordering.
@@ -36,7 +42,19 @@ effective dimension (functions where the first few inputs dominate the evaluatio
 
 The Faure sequence in dimension `s` forms a `(0, s)`-sequence with base `b = nextprime(s)`.
 
-A Faure sequence must have length `k * base^s` with `k < base < 1`.
+A Faure sequence must have a supported length of `k * base^s` with an integer
+`k` satisfying `1 ≤ k < base`.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(8, 2, FaureSample());
+
+julia> size(points)
+(2, 8)
+```
 
 References:
 Faure, H. (1982). Discrépance de suites associées à un système de numération (en dimension s). *Acta Arith.*, 41, 337-351.

--- a/src/Halton.jl
+++ b/src/Halton.jl
@@ -1,7 +1,22 @@
 """
     HaltonSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
-Create a Halton sequence.
+Create a Halton sequence using successive prime bases.
+
+# Fields
+
+- `R::RandomizationMethod = NoRand()`: Randomization applied to the sequence.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(8, 2, HaltonSample());
+
+julia> size(points)
+(2, 8)
+```
 """
 Base.@kwdef @concrete struct HaltonSample <: DeterministicSamplingAlgorithm
     R::RandomizationMethod = NoRand()

--- a/src/Kronecker.jl
+++ b/src/Kronecker.jl
@@ -1,7 +1,8 @@
 """
     KroneckerSample(generator::AbstractVector, R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
+    KroneckerSample(d::Integer, R::RandomizationMethod = NoRand(), T = Float64)
 
-A Kronecker sequence is a point set generated using a vector and equation:
+A Kronecker sequence is a point set generated using a vector and the equation
 `x[i] = i * generator .% 1`
 
 Where `i` runs from `1` through the sample size `n`. This sequence will be equidistributed
@@ -14,6 +15,31 @@ If no generator is specified, a lattice based on the generalized golden ratio is
 Kronecker sequences are not recommended for use in more than 3 dimensions, as theory on them
 is sparse. `LatticeRuleSample` will return rank-1 lattice rules, which behave similarly to
 Kronecker sequences but have better properties.
+
+# Fields
+
+- `generator::AbstractVector`: Generator vector. Its length must equal the
+  requested dimension.
+- `R::RandomizationMethod = NoRand()`: Randomization applied to the generated
+  sequence.
+
+# Arguments
+
+- `d::Integer`: Dimension for the constructor that creates a generalized
+  golden-ratio generator.
+- `R::RandomizationMethod`: Optional randomization method.
+- `T`: Element type used for the generated generator.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(8, 2, KroneckerSample(2));
+
+julia> size(points)
+(2, 8)
+```
 
 References:
 Leobacher, G., & Pillichshammer, F. (2014). *Introduction to quasi-Monte Carlo integration and applications.* Switzerland: Springer International Publishing.
@@ -67,6 +93,22 @@ References:
 Roberts, M. (2018). The Unreasonable Effectiveness of Quasirandom Sequences.
 *Extreme Learning.*
 http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+
+# Returns
+
+- A [`KroneckerSample`](@ref) configured with a generalized golden-ratio
+  generator.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(8, 2, GoldenSample());
+
+julia> size(points)
+(2, 8)
+```
 """
 GoldenSample(args...; kwargs...) = KroneckerSample(args...; kwargs...)
 

--- a/src/LatinHypercube.jl
+++ b/src/LatinHypercube.jl
@@ -1,7 +1,26 @@
 """
     LatinHypercubeSample(rng::AbstractRNG = Random.TaskLocalRNG()) <: RandomSamplingAlgorithm
 
-A Latin Hypercube is a point set with the property that every one-dimensional interval `(i/n, i+1/n)` contains exactly one point. This is a good way to sample a high-dimensional space, as it is more uniform than a random sample but does not require as many points as a full net.
+A Latin hypercube is a point set with the property that every one-dimensional
+interval `(i / n, (i + 1) / n)` contains exactly one point. It is useful for
+high-dimensional sampling because it is more uniform than independent Monte
+Carlo sampling without requiring a full tensor-product grid.
+
+# Fields
+
+- `rng::AbstractRNG = Random.TaskLocalRNG()`: Random-number generator used to
+  independently permute the strata in each dimension.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo, Random
+
+julia> points = sample(8, 2, LatinHypercubeSample(MersenneTwister(42)));
+
+julia> size(points)
+(2, 8)
+```
 """
 Base.@kwdef @concrete struct LatinHypercubeSample <: RandomSamplingAlgorithm
     rng::AbstractRNG = Random.TaskLocalRNG()

--- a/src/Lattices.jl
+++ b/src/Lattices.jl
@@ -1,7 +1,12 @@
 """
     GridSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
-A simple rectangular grid lattice. Samples `n` random samples from a grid with `dx = (ub -lb)/n``
+A simple rectangular grid lattice. It samples from a regular grid in the unit
+box and optionally applies `R`.
+
+# Fields
+
+- `R::RandomizationMethod = NoRand()`: Randomization applied to the grid.
 
 In more than 2 dimensions, grids have worse discrepancy than simple Monte Carlo. As a
 result, they should almost never be used for multivariate integration; their use is as
@@ -17,9 +22,25 @@ function sample(n::Integer, d::Integer, S::GridSample, T = Float64)
 end
 
 """
-    LatticeRuleSample() <: DeterministicSamplingAlgorithm
+    LatticeRuleSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
-Generate a point set using a lattice rule.
+Generate a point set using a rank-1 lattice rule.
+
+# Fields
+
+- `R::RandomizationMethod = NoRand()`: Randomization applied to the lattice
+  points.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(8, 2, LatticeRuleSample());
+
+julia> size(points)
+(2, 8)
+```
 """
 Base.@kwdef @concrete struct LatticeRuleSample <: DeterministicSamplingAlgorithm
     R::RandomizationMethod = NoRand()

--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -1,3 +1,14 @@
+"""
+    QuasiMonteCarlo
+
+Generate deterministic and randomized quasi-Monte Carlo point sets.
+
+The primary interface is [`sample`](@ref), which returns points as columns of
+a matrix. Deterministic samplers can be combined with [`randomize`](@ref),
+[`DesignMatrix`](@ref), or [`generate_design_matrices`](@ref) for randomized
+realizations and error estimation. Package developers can extend the generic
+sampler contract described on the [Developer API](@ref DeveloperAPI) page.
+"""
 module QuasiMonteCarlo
 
 using Sobol: Sobol
@@ -14,7 +25,7 @@ using SciMLPublic: @public
 
 Abstract supertype for sampling strategies accepted by [`sample`](@ref).
 
-## Extension rules
+# Extension rules
 
 Define a concrete subtype and implement
 `sample(n::Integer, d::Integer, sampler::YourSampler, T = Float64)`.
@@ -29,21 +40,65 @@ abstract type SamplingAlgorithm end
 """
     RandomSamplingAlgorithm <: SamplingAlgorithm
 
-Abstract supertype for samplers that use an RNG to generate randomized point sets.
+Abstract interface for samplers that generate randomized point sets.
+
+Subtypes must implement the unit-box method
+`sample(n::Integer, d::Integer, sampler, T = Float64)` described by
+[`SamplingAlgorithm`](@ref). The implementation must use the sampler's
+randomness, return a `d`-by-`n` matrix with entries in `[0, 1]`, and preserve
+the requested element type when `T` is supplied.
+
+The `generate_design_matrices` interface treats each call to `sample` as an
+independent realization. A sampler should therefore store its random state in
+a field, such as the `rng` field on [`RandomSample`](@ref), and should not
+cache a point set between calls unless that behavior is part of its contract.
+
+This type is a developer-facing interface and is not exported. Refer to it as
+`QuasiMonteCarlo.RandomSamplingAlgorithm` when defining an extension.
 """
 abstract type RandomSamplingAlgorithm <: SamplingAlgorithm end
+@public RandomSamplingAlgorithm
 
 """
     DeterministicSamplingAlgorithm <: SamplingAlgorithm
 
-Abstract supertype for deterministic low-discrepancy samplers.
+Abstract interface for deterministic low-discrepancy samplers.
+
+Subtypes must implement the unit-box method
+`sample(n::Integer, d::Integer, sampler, T = Float64)` described by
+[`SamplingAlgorithm`](@ref). The underlying sequence must be deterministic
+for equivalent sampler state; a non-`NoRand` `R` field may intentionally add
+randomization to the returned point set. The result must be a `d`-by-`n`
+matrix with entries in `[0, 1]` and element type `T` when `T` is supplied.
+
+To use the generic [`DesignMatrix`](@ref) or
+[`generate_design_matrices`](@ref) interfaces, a concrete subtype must also
+provide an `R::RandomizationMethod` field. That field supplies the default
+randomization method. A custom randomization method must follow the
+[`RandomizationMethod`](@ref) contract.
+
+This type is a developer-facing interface and is not exported. Refer to it as
+`QuasiMonteCarlo.DeterministicSamplingAlgorithm` when defining an extension.
 """
 abstract type DeterministicSamplingAlgorithm <: SamplingAlgorithm end
+@public DeterministicSamplingAlgorithm
 
 """
     RandomizationMethod
 
-Abstract supertype for methods that randomize deterministic point sets with [`randomize`](@ref).
+Abstract interface for methods that randomize deterministic point sets with
+[`randomize`](@ref).
+
+An implementation must preserve the shape of its input point matrix and keep
+every point in the unit box. It should provide
+`randomize(points::AbstractMatrix, method)` and return a new matrix unless the
+method is explicitly documented as mutating its input. The randomization must
+preserve the low-discrepancy properties promised by the concrete method and
+should use an owned or supplied random-number generator for reproducibility.
+
+Deterministic samplers store their default randomization method in an `R`
+field. Pass a method explicitly to `randomize` when a different randomization
+is needed for an existing point set.
 """
 abstract type RandomizationMethod end
 
@@ -100,15 +155,34 @@ _check_sequence(n::Integer) = @assert n > 0 ZERO_SAMPLES_MESSAGE
 """
     RandomSample(; rng = Random.TaskLocalRNG()) <: RandomSamplingAlgorithm
 
-Plain Monte Carlo sampler that draws independent uniform samples from the unit box.
+Plain Monte Carlo sampler that draws independent uniform samples from the unit
+box.
+
+# Fields
+
+- `rng::AbstractRNG`: random-number generator used for each call to
+  [`sample`](@ref).
+
+# Keywords
+
+- `rng::AbstractRNG = Random.TaskLocalRNG()`: random-number generator used to
+  draw the samples. Supply a seeded RNG for reproducible results.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo, Random
+
+julia> sampler = RandomSample(MersenneTwister(42));
+
+julia> points = sample(4, 2, sampler);
+
+julia> size(points)
+(2, 4)
+```
 """
 Base.@kwdef @concrete struct RandomSample <: RandomSamplingAlgorithm
     rng::AbstractRNG = Random.TaskLocalRNG()
-end
-
-function sample(n::Integer, d::Integer, S::RandomSample, T = Float64)
-    _check_sequence(n)
-    return rand(S.rng, T, d, n)
 end
 
 """
@@ -117,31 +191,36 @@ end
 
 Generate `n` sample points with `sampler`.
 
-## Arguments
+# Arguments
 
-  - `n`: Positive number of points to generate.
-  - `d`: Positive dimension of the unit box. This form returns a `d`-by-`n`
-    matrix with values in `[0, 1]`.
-  - `lb`: Scalar, tuple, or vector of lower bounds. Its length determines the
-    dimension when it is not scalar.
-  - `ub`: Scalar, tuple, or vector of upper bounds with the same shape as `lb`.
-    Each lower bound must be less than or equal to its corresponding upper bound.
-  - `sampler`: Concrete [`SamplingAlgorithm`](@ref) that determines the point
-    set construction.
+- `n`: Positive number of points to generate.
+- `d`: Positive dimension of the unit box. This form returns a `d`-by-`n`
+  matrix with values in `[0, 1]`.
+- `lb`: Scalar, tuple, or vector of lower bounds. Its length determines the
+  dimension when it is not scalar.
+- `ub`: Scalar, tuple, or vector of upper bounds with the same shape as `lb`.
+  Each lower bound must be less than or equal to its corresponding upper bound.
+- `sampler`: Concrete [`SamplingAlgorithm`](@ref) that determines the point
+  set construction.
 
-## Optional Positional Arguments
+# Arguments with defaults
 
-  - `T = Float64`: Element type of the unit-box result. The bounds form infers
-    its output element type from `lb`.
+- `T = Float64`: Element type of the unit-box result. The bounds form infers
+  its output element type from `lb`.
 
-## Returns
+# Returns
 
 A matrix whose columns are the generated points. The unit-box form has size
 `(d, n)`. The bounds form has size `(length(lb), n)` for collection bounds and
 maps every coordinate from `[0, 1]` to its corresponding closed interval
 `[lb[i], ub[i]]`.
 
-## Examples
+# Throws
+
+- `AssertionError`: If `n` is not positive, the bounds have different lengths,
+  or a lower bound exceeds its corresponding upper bound.
+
+# Examples
 
 ```jldoctest
 julia> using QuasiMonteCarlo
@@ -157,7 +236,7 @@ julia> all([0.0, -1.0] .<= points .<= [1.0, 1.0])
 true
 ```
 
-## Extension rules
+# Extension rules
 
 To add a sampler, subtype [`SamplingAlgorithm`](@ref) and implement only the
 unit-box form `sample(n, d, sampler, T)`. The implementation must return a
@@ -165,6 +244,11 @@ unit-box form `sample(n, d, sampler, T)`. The implementation must return a
 package and delegates to that unit-box method. Do not extend this bounds method
 for a new sampler.
 """
+function sample(n::Integer, d::Integer, S::RandomSample, T = Float64)
+    _check_sequence(n)
+    return rand(S.rng, T, d, n)
+end
+
 function sample(
         n::Integer, lb::T, ub::T,
         S::D
@@ -200,15 +284,53 @@ include("Section.jl")
 """
     NoRand() <: RandomizationMethod
 
-No randomization is performed on the sampled sequence.
+Identity randomization for deterministic samplers.
+
+`randomize(points, NoRand())` returns `points` unchanged. It is also the
+default value of the `R` field on deterministic sampler types.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(4, 2, SobolSample(R = NoRand()));
+
+julia> randomize(points, NoRand()) === points
+true
+```
 """
 struct NoRand <: RandomizationMethod end
 
 """
     randomize(x, R::RandomizationMethod)
 
-Apply the randomization method `R` to the sample matrix `x`.
-The `NoRand()` method returns `x` unchanged.
+Apply the randomization method `R` to a sample matrix `x`.
+
+# Arguments
+
+- `x::AbstractMatrix`: Matrix with one point per column. Its entries must be
+  in the unit box expected by the selected randomization method.
+- `R::RandomizationMethod`: Randomization strategy to apply.
+
+# Returns
+
+- A matrix with the same size as `x`, with each point randomized according to
+  `R`. `NoRand()` returns the original matrix unchanged; other methods return
+  a new matrix unless their method documentation says otherwise.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(4, 2, SobolSample());
+
+julia> randomized = randomize(points, Shift());
+
+julia> size(randomized) == size(points)
+true
+```
 """
 randomize(x, S::NoRand) = x
 

--- a/src/RandomizedHalton.jl
+++ b/src/RandomizedHalton.jl
@@ -1,7 +1,24 @@
 """
     RandomizedHaltonSample(; rng = Random.TaskLocalRNG()) <: RandomSamplingAlgorithm
 
-Create a randomized Halton sequence.
+Create a randomized Halton sequence by independently permuting the radical
+inverse digits in each dimension.
+
+# Fields
+
+- `rng::AbstractRNG = Random.TaskLocalRNG()`: Random-number generator used for
+  the digit permutations.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo, Random
+
+julia> points = sample(8, 2, RandomizedHaltonSample(rng = MersenneTwister(42)));
+
+julia> size(points)
+(2, 8)
+```
 
 References:
 Owen, A. (2017). *A randomized Halton algorithm in R*. https://doi.org/10.48550/arXiv.1706.02808

--- a/src/RandomizedQuasiMonteCarlo/iterators.jl
+++ b/src/RandomizedQuasiMonteCarlo/iterators.jl
@@ -1,4 +1,22 @@
+"""
+    AbstractDesignMatrix
+
+Developer-facing interface for iterators returned by [`DesignMatrix`](@ref).
+
+Concrete subtypes must store a `count` field and implement
+`next!(iterator)`, which produces the next point-set matrix. The generic
+`Base.length` and `Base.iterate` methods use those two pieces of the contract:
+iteration yields exactly `count` matrices, and each call to `next!` may reuse
+internal storage but must return a complete matrix before the next iteration
+step mutates that storage.
+
+Implementations should also define `Base.eltype(::Type{<:AbstractDesignMatrix})`
+to describe the matrix type yielded by iteration. This interface is intended
+for package developers extending the design-matrix machinery; application code
+should call [`DesignMatrix`](@ref) and iterate over its result.
+"""
 abstract type AbstractDesignMatrix end
+@public AbstractDesignMatrix
 
 # Make an iterator so that we can do "for X in DesignMatrix(...)"
 Base.length(s::AbstractDesignMatrix) = s.count
@@ -78,18 +96,58 @@ Base.eltype(::Type{DistributionDesignMat{T}}) where {T} = Matrix{T}
 Base.eltype(::Type{RandomDesignMat{T}}) where {T} = Matrix{T} # TODO one could create a type for AbstractDistribution to include RandomDesignMat and DistributionDesignMat
 
 """
-```julia
-DesignMatrix(n, d, sample_method::DeterministicSamplingAlgorithm, num_mats, T = Float64)
+    DesignMatrix(n, d, sampler, num_mats, T = Float64)
+    DesignMatrix(n, d, sampler, randomization, num_mats, T = Float64)
+
+Create an iterator that produces `num_mats` point-set matrices.
+
+The iterator is useful when a computation needs independent randomized QMC
+realizations but allocating all matrices at once is undesirable. For a
+deterministic sampler, the five-argument form uses the sampler's `R` field;
+the six-argument form selects `randomization` explicitly. `RandomSample` also
+has a five-argument form and generates independent Monte Carlo matrices.
+
+# Arguments
+
+- `n::Integer`: Number of points in each matrix.
+- `d::Integer`: Dimension of each point. Each yielded matrix has size `(d, n)`.
+- `sampler`: Deterministic or random [`SamplingAlgorithm`](@ref).
+- `randomization::RandomizationMethod`: Randomization applied to a
+  deterministic sampler.
+- `num_mats::Integer`: Number of matrices yielded by the iterator.
+- `T::DataType = Float64`: Element type of each matrix.
+
+# Returns
+
+- An [`AbstractDesignMatrix`](@ref) iterator whose elements are matrices of
+  size `(d, n)` and element type `T`.
+
+# Throws
+
+- An exception from the selected sampler or randomization method if `n`, `d`,
+  the randomization base, or the sampler-specific parameters are invalid.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> iterator = DesignMatrix(4, 2, SobolSample(R = Shift()), 3);
+
+julia> length(iterator)
+3
+
+julia> size(first(iterator))
+(2, 4)
 ```
 
-Create an iterator for doing multiple i.i.d. randomization over QMC sequences where
+# Extension rules
 
-  - `num_mats` is the length of the iterator
-  - `n` is the number of points to sample.
-  - `d` is the dimensionality of the point set in `[0, 1)ᵈ`,
-  - `sample_method` is the quasi-Monte Carlo sampling strategy used to create a deterministic point set `out`.
-  - `T` is the `eltype` of the point sets. For some QMC methods (Faure, Sobol) this can be `Rational`
-    It is now compatible with all scrambling methods and shifting. One can also use it with `Distributions.Sampleable` or `RandomSample`.
+For a custom deterministic sampler, define the unit-box `sample` method from
+[`SamplingAlgorithm`](@ref) and provide an `R::RandomizationMethod` field.
+The built-in randomization-specific `initialize` methods are implementation
+details; custom extensions should use the public `sample` and `randomize`
+contracts unless they are deliberately implementing a compatible iterator.
 """
 function DesignMatrix(
         N, d, S::DeterministicSamplingAlgorithm, num_mats::Integer, T::DataType = Float64
@@ -224,7 +282,7 @@ end
 
 Generate multiple point-set matrices with `sampler`.
 
-## Arguments
+# Arguments
 
   - `n`: Positive number of points in each generated matrix.
   - `d`: Positive dimension of the unit box. This form returns matrices of size
@@ -235,16 +293,22 @@ Generate multiple point-set matrices with `sampler`.
     point set.
   - `num_mats`: Number of matrices to generate.
 
-## Optional Positional Arguments
+# Optional positional arguments
 
   - `T = Float64`: Element type of the unit-box matrices.
 
-## Returns
+# Returns
 
 A vector of `num_mats` matrices. Each unit-box matrix has size `(d, n)`. The
 bounds form maps every coordinate to its corresponding interval `[lb[i], ub[i]]`.
 
-## Examples
+# Throws
+
+- `AssertionError`: If the bounds have different lengths or a lower bound
+  exceeds its corresponding upper bound.
+- An exception from the selected sampler if `n`, `d`, or `num_mats` is invalid.
+
+# Examples
 
 ```jldoctest
 julia> using QuasiMonteCarlo
@@ -258,7 +322,7 @@ julia> all(size(matrix) == (2, 4) for matrix in matrices)
 true
 ```
 
-## Developer Notes
+# Developer Notes
 
 This function builds on the public [`sample`](@ref) contract. New sampling
 algorithms should extend `sample`; they should not add methods to

--- a/src/RandomizedQuasiMonteCarlo/scrambling_base_b.jl
+++ b/src/RandomizedQuasiMonteCarlo/scrambling_base_b.jl
@@ -2,11 +2,35 @@
 #TODO the typing could probably improved, resulting in more type stable (important for QMC computation to be able to use Float32, Float64, Rational, ... for points, and Int64, Int32, Int16 etc for bits etc.)
 
 """
-```julia
-ScrambleMethod <: RandomizationMethod
+    ScrambleMethod <: RandomizationMethod
+
+A scramble method randomizes a digital net in an integer base.
+
+# Interface rules
+
+Concrete subtypes must provide the fields `base::Integer`, `pad::Integer`,
+and `rng::AbstractRNG`. `base` must match the base of the sequence being
+scrambled, and `pad` must be at least `log(base, n)` for a point set with `n`
+points. The `randomize` interface preserves the matrix size and keeps points in
+the unit box.
+
+The package provides [`DigitalShift`](@ref), [`MatousekScramble`](@ref), and
+[`OwenScramble`](@ref). New implementations should add methods to the generic
+`randomize`/`randomize!` interface rather than changing sampler methods.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(8, 2, FaureSample());
+
+julia> randomized = randomize(points, DigitalShift(base = 2, pad = 4));
+
+julia> size(randomized) == size(points)
+true
 ```
 
-A scramble method needs at least the scrambling base `b`, the number of "bits" to use `pad` (`pad=32` is the default) and an RNG (`rng = Random.TaskLocalRNG()` by default).
 The scramble methods implementer are
 
   - `DigitalShift`.
@@ -15,16 +39,6 @@ The scramble methods implementer are
 """
 abstract type ScrambleMethod <: RandomizationMethod end
 
-"""
-    randomize(x, R::ScrambleMethod)
-
-Return a scrambled version of `x`.
-The scramble methods implemented are
-
-  - `DigitalShift`.
-  - `OwenScramble`: Nested Uniform Scramble which was introduced in Owen (1995).
-  - `MatousekScramble`: Linear Matrix Scramble which was introduced in Matousek (1998).
-"""
 function randomize(x, R::ScrambleMethod)
     random_x = permutedims(copy(x))
     randomize!(random_x, permutedims(x), R)
@@ -32,11 +46,16 @@ function randomize(x, R::ScrambleMethod)
 end
 
 """
-```julia
-OwenScramble <: ScrambleMethod
-```
+    OwenScramble(base::Integer; pad = 32, rng = Random.TaskLocalRNG()) <: ScrambleMethod
 
-Nested Uniform Scramble aka Owen's scramble.
+Nested Uniform Scramble, also known as Owen's scramble.
+
+# Fields
+
+- `base::Integer`: Base of the digital net being scrambled.
+- `pad::Integer = 32`: Number of base-`base` digits retained for each point.
+- `rng::AbstractRNG = Random.TaskLocalRNG()`: Random-number generator used by
+  the scramble.
 
 `randomize(x, R::OwenScramble)` returns a scrambled version of `x`.
 The scramble method is Nested Uniform Scramble which was introduced in Owen (1995).
@@ -168,11 +187,16 @@ function randomize!(
 end
 
 """
-```julia
-MatousekScramble <: ScrambleMethod
-```
+    MatousekScramble(base::Integer; pad = 32, rng = Random.TaskLocalRNG()) <: ScrambleMethod
 
-Linear Matrix Scramble aka Matousek's scramble.
+Linear Matrix Scramble, also known as Matousek's scramble.
+
+# Fields
+
+- `base::Integer`: Base of the digital net being scrambled.
+- `pad::Integer = 32`: Number of base-`base` digits retained for each point.
+- `rng::AbstractRNG = Random.TaskLocalRNG()`: Random-number generator used by
+  the scramble.
 
 `randomize(x, R::MatousekScramble)` returns a scrambled version of `x`.
 The scramble method is Linear Matrix Scramble which was introduced in Matousek (1998).
@@ -245,12 +269,17 @@ end
 getmatousek(m::Integer, b::Integer) = getmatousek(Random.TaskLocalRNG(), m, b)
 
 """
-```julia
-DigitalShift <: ScrambleMethod
-```
+    DigitalShift(base::Integer; pad = 32, rng = Random.TaskLocalRNG()) <: ScrambleMethod
 
 Digital shift.
 `randomize(x, R::DigitalShift)` returns a scrambled version of `x`.
+
+# Fields
+
+- `base::Integer`: Base of the digital net being scrambled.
+- `pad::Integer = 32`: Number of base-`base` digits retained for each point.
+- `rng::AbstractRNG = Random.TaskLocalRNG()`: Random-number generator used by
+  the shift.
 
 The scramble method is Digital Shift.
 It scrambles each coordinate in base `b` as `yₖ = (xₖ + Uₖ) mod b` where `Uₖ ∼ 𝕌({0:b-1})`.

--- a/src/RandomizedQuasiMonteCarlo/shifting.jl
+++ b/src/RandomizedQuasiMonteCarlo/shifting.jl
@@ -3,17 +3,30 @@
 
 Cranley-Patterson rotation.
 
+# Fields
+
+- `rng::AbstractRNG = Random.TaskLocalRNG()`: Random-number generator used to
+  draw one shift vector for each call to [`randomize`](@ref).
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo, Random
+
+julia> points = sample(8, 2, SobolSample());
+
+julia> shifted = randomize(points, Shift(rng = MersenneTwister(42)));
+
+julia> size(shifted) == size(points)
+true
+```
+
 References: Cranley, R., & Patterson, T. N. (1976). Randomization of number theoretic methods for multiple integration. SIAM Journal on Numerical Analysis, 13(6), 904-914.
 """
 Base.@kwdef @concrete struct Shift <: RandomizationMethod
     rng::AbstractRNG = Random.TaskLocalRNG()
 end
 
-"""
-    randomize(x, R::Shift)
-
-Cranley Patterson Rotation i.e. `y = (x .+ U) mod 1` where `U ∼ 𝕌([0,1]ᵈ)` and `x` is a `d×n` matrix
-"""
 function randomize(x, R::Shift)
     y = copy(x)
     shift!(R.rng, y)

--- a/src/Sobol.jl
+++ b/src/Sobol.jl
@@ -2,6 +2,22 @@
     SobolSample(R::RandomizationMethod = NoRand()) <: DeterministicSamplingAlgorithm
 
 Samples taken from Sobol's base-2 sequence.
+
+# Fields
+
+- `R::RandomizationMethod = NoRand()`: Randomization applied to the Sobol
+  points.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(8, 2, SobolSample());
+
+julia> size(points)
+(2, 8)
+```
 """
 Base.@kwdef @concrete struct SobolSample <: DeterministicSamplingAlgorithm
     R::RandomizationMethod = NoRand()

--- a/src/VanDerCorput.jl
+++ b/src/VanDerCorput.jl
@@ -9,6 +9,23 @@ For example, in base 2, the sequence starts by inserting one point in each half 
 interval in the first pass (the first 2 samples); then one sample in each quarter, then each
 eighth, and so on. This creates a well-stratified sample, so long as the number of samples
 is a multiple of a power of the base.
+The one-dimensional result is returned as a vector of length `n`.
+
+# Fields
+
+- `base::Integer`: Base used for the radical-inverse expansion.
+- `R::RandomizationMethod = NoRand()`: Randomization applied to the sequence.
+
+# Examples
+
+```jldoctest
+julia> using QuasiMonteCarlo
+
+julia> points = sample(8, 1, VanDerCorputSample(base = 2));
+
+julia> size(points)
+(8,)
+```
 """
 Base.@kwdef @concrete struct VanDerCorputSample{I <: Integer} <:
     DeterministicSamplingAlgorithm

--- a/test/public_api.jl
+++ b/test/public_api.jl
@@ -1,7 +1,13 @@
 using QuasiMonteCarlo
 using Test
 
-struct ConstantSampler <: SamplingAlgorithm end
+struct ConstantSampler <: QuasiMonteCarlo.RandomSamplingAlgorithm end
+
+struct GenericDeterministicSampler <: QuasiMonteCarlo.DeterministicSamplingAlgorithm
+    R::RandomizationMethod
+end
+
+GenericDeterministicSampler() = GenericDeterministicSampler(Shift())
 
 hasdoc(mod::Module, name::Symbol) = haskey(Base.Docs.meta(mod), Base.Docs.Binding(mod, name))
 
@@ -43,6 +49,47 @@ end
         3, [-2.0, 4.0], [2.0, 6.0], RandomSample(), 2
     )
     @test all(all([-2.0, 4.0] .<= matrix .<= [2.0, 6.0]) for matrix in bounded_matrices)
+end
+
+@testset "Developer interface metadata" begin
+    for name in (
+            :RandomSamplingAlgorithm, :DeterministicSamplingAlgorithm,
+            :AbstractDesignMatrix,
+        )
+        @test isdefined(QuasiMonteCarlo, name)
+        @test hasdoc(QuasiMonteCarlo, name)
+        @static if VERSION >= v"1.11"
+            @test Base.ispublic(QuasiMonteCarlo, name)
+        end
+    end
+end
+
+function QuasiMonteCarlo.sample(
+        n::Integer, d::Integer, ::GenericDeterministicSampler, T = Float64
+    )
+    return fill(convert(T, 0.25), d, n)
+end
+
+@testset "Generic sampler contracts" begin
+    sampler = GenericDeterministicSampler()
+
+    unit_points = sample(3, 2, sampler, Float32)
+    @test size(unit_points) == (2, 3)
+    @test eltype(unit_points) == Float32
+    @test all(0 .<= unit_points .<= 1)
+
+    bounded_points = sample(3, [-2.0, 4.0], [2.0, 6.0], sampler)
+    @test size(bounded_points) == (2, 3)
+    @test all([-2.0, 4.0] .<= bounded_points .<= [2.0, 6.0])
+
+    matrices = generate_design_matrices(3, 2, sampler, 2, Float32)
+    @test length(matrices) == 2
+    @test all(size(matrix) == (2, 3) for matrix in matrices)
+    @test all(eltype(matrix) == Float32 for matrix in matrices)
+
+    iterator = DesignMatrix(3, 2, sampler, 2, Float32)
+    @test length(iterator) == 2
+    @test all(size(matrix) == (2, 3) for matrix in iterator)
 end
 
 @testset "Developer sequence validation API" begin


### PR DESCRIPTION
This draft should be ignored until reviewed by @ChrisRackauckas.

This docs-only follow-up audits QuasiMonteCarlo against the SciMLStyle definition-site documentation and SciMLBase-style interface requirements.

What changed:
- Added definition-site module, sampler, randomization, scrambling, and design-matrix documentation with fields, arguments, defaults, returns, throws, examples, and extension rules.
- Marked the developer-facing `RandomSamplingAlgorithm`, `DeterministicSamplingAlgorithm`, and `AbstractDesignMatrix` interfaces public and documented them on a dedicated Developer API page.
- Added generic contract tests for a custom deterministic sampler through `sample`, `generate_design_matrices`, and `DesignMatrix`.
- Reworked the Distributions extension docstrings and removed stale/source-path documentation links.
- Confirmed root and QA test environments retain `SciMLTesting = "2.4"`; no repository-specific API-doc QA overrides are present.

Verification:
- `GROUP=Core timeout 3600 julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: `Core/core.jl | 405 405`; `Core/public_api.jl | 42 42`; exit 0.
- `GROUP=QA timeout 3600 julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: `QA/qa.jl | 20 20`; exit 0. SciMLTesting resolved to 2.10.0 under the 2.4 lower bound.
- `timeout 3600 bash -lc 'julia --startup-file=no --project=docs -e ... include("docs/make.jl")'`: `DOCS_EXIT:0`, including doctests, cross-references, document checks, rendering, and link checking. Documenter emitted only the existing HTML-size and deployment-environment warnings.
- Runic format check: 14 changed Julia files clean.
- `typos` over the changed files: passed.
- `git diff --check`: passed.
- Runtime public metadata audit: no public names missing definition-site docs.

No algorithm or runtime behavior was changed.