### PR TITLE
Replace IntervalBox so IntervalArithmetic 1 Core tests pass

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -54,7 +54,7 @@ function istmsnet(
     perms = multiexponents(s, m - t)
     for stepsize in perms
         intervals = mince(
-            IntervalBox([interval(zero(T), one(T)) for i in 1:s]),
+            [interval(zero(T), one(T)) for i in 1:s],
             NTuple{s, Int}(base .^ stepsize)
         )
         pass &= all(intervals) do intvl
@@ -75,9 +75,9 @@ Checks if the number `x` is a member of the interval `a` (close on the left and 
 """
 function inCloseOpen(x::T, a::Interval) where {T <: Real}
     isinf(x) && return false
-    return a.lo <= x < a.hi
+    return inf(a) <= x < sup(a)
 end
-inCloseOpen(X::AbstractVector, Y::IntervalBox{N, T}) where {N, T} = all(inCloseOpen.(X, Y))
+inCloseOpen(X::AbstractVector, Y::AbstractVector{<:Interval}) = all(inCloseOpen.(X, Y))
 
 rng = MersenneTwister(1776)
 


### PR DESCRIPTION
Replace IntervalBox in Core tests so IntervalArithmetic 1 (latest live major) can run.

Follow-up to bound-only https://github.com/SciML/QuasiMonteCarlo.jl/pull/179. IA 1 dropped `IntervalBox`; `test/core.jl` still constructed it and read `Interval.lo` / `Interval.hi`. That is `UndefVarError: IntervalBox` on IA 1.0.11, so `[compat] IntervalArithmetic = "1"` from https://github.com/SciML/QuasiMonteCarlo.jl/pull/177 could not actually test against the declared major.

`istmsnet` now minces a `Vector{<:Interval}` (IA 1 replacement for a box) and uses `inf` / `sup` for half-open membership. `[compat] IntervalArithmetic` stays `"1"` — 0.21 is no longer needed.

This PR should be ignored until reviewed by @ChrisRackauckas.

## Verification

Fail-before (IA 1.0.11, unfixed helper):

```
IA 1.0.11
IntervalBox defined? false
FAIL-BEFORE: UndefVarError: `IntervalBox` not defined
```

Pass-after, Julia 1.10.11, `JULIA_DEPOT_PATH=$HOME/sandbox/julia-depots/qmc-ia1`, `TMPDIR=$HOME/tmp`:

```
GROUP=Core julia +1.10 --project -e 'using Pkg; Pkg.test()'
```

Resolved `IntervalArithmetic v1.0.11`. Tail:

```
Test Summary: | Pass  Total      Time
Core/core.jl  |  405    405  22m28.7s
Test Summary:      | Pass  Total  Time
Core/public_api.jl |   38     38  5.4s
     Testing QuasiMonteCarlo tests passed
```

```
GROUP=QA julia +1.10 --project -e 'using Pkg; Pkg.test()'
```

```
Test Summary: | Pass  Total   Time
QA/qa.jl      |   18     18  26.7s
     Testing QuasiMonteCarlo tests passed
```

Runic `--check test/core.jl` and `typos test/core.jl` passed. Docs build not run (no docstring / `docs/` / public API change). GPU, downstream, and allowed-to-fail jobs not run.

## Reviewer notes

Source-only test helper change. No public API change. Bound-only PR https://github.com/SciML/QuasiMonteCarlo.jl/pull/179 can stay or be closed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
