### PR TITLE
Bump QuasiMonteCarlo to 0.4.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuasiMonteCarlo"
 uuid = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 authors = ["ludoro <ludovicobessi@gmail.com>, Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
Bumps the version so the src changes already merged to `master` can be registered in the General registry.

- QuasiMonteCarlo: 0.4.1 -> 0.4.2

No code changes — version metadata only.

[#180](https://github.com/SciML/QuasiMonteCarlo.jl/pull/180) replaced `IntervalBox` so Core tests pass on IntervalArithmetic 1. Registered 0.4.1 still has `IntervalArithmetic = "0.21"`.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)