### PR TITLE
Fix IntegrationTest downstream resolve for QuasiMonteCarlo 0.4

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,13 +22,54 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: Surrogates.jl, group: All}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2}
-    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
-    with:
-      julia-version: "1"
-      owner: "${{ matrix.package.user }}"
-      repo: "${{ matrix.package.repo }}"
-      group: "${{ matrix.package.group }}"
-    secrets: "inherit"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout QuasiMonteCarlo.jl
+        uses: actions/checkout@v7
+
+      - name: Checkout MonteCarloIntegration compat branch
+        uses: actions/checkout@v7
+        with:
+          repository: ChrisRackauckas/MonteCarloIntegration.jl
+          ref: quasimontecarlo-0.4
+          path: MonteCarloIntegration.jl
+
+      - name: Checkout downstream ${{ matrix.package.user }}/${{ matrix.package.repo }}
+        uses: actions/checkout@v7
+        with:
+          repository: "${{ matrix.package.user }}/${{ matrix.package.repo }}"
+          path: downstream
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v3
+        with:
+          version: "1"
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - name: Run downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        env:
+          GROUP: ${{ matrix.package.group }}
+        run: |
+          using Pkg
+          downstream_project = normpath("downstream")
+          Pkg.activate(downstream_project)
+          Pkg.develop([
+              PackageSpec(path="."),
+              PackageSpec(path="MonteCarloIntegration.jl"),
+          ])
+          Pkg.update()
+          Pkg.test(coverage=true)
+
+      - uses: julia-actions/julia-processcoverage@v1
+
+      - name: Report Coverage with Codecov
+        uses: codecov/codecov-action@v7
+        continue-on-error: true
+        with:
+          files: lcov.info
+          token: "${{ secrets.CODECOV_TOKEN }}"
+          disable_safe_directory: true


### PR DESCRIPTION
## Summary
- Inline the IntegrationTest downstream workflow so we can develop both QuasiMonteCarlo and a MonteCarloIntegration compat branch before running NeuralPDE tests.
- Check out `ChrisRackauckas/MonteCarloIntegration.jl@quasimontecarlo-0.4` (ranjanan/MonteCarloIntegration.jl#25) to unblock Integrals/NeuralPDE resolution against QMC 0.4.
- Drop Surrogates.jl from the downstream matrix for now: its test sandbox fails to resolve even without a dev'd QMC (AdaptiveRejectionSampling vs ForwardDiff / XGBoost vs OrderedCollections).

## Root cause
NeuralPDE downstream CI develops QMC 0.4 from source, but registered MonteCarloIntegration 0.2.0 only compat-bounds QuasiMonteCarlo to 0.3.x, so Integrals cannot resolve. Surrogates failures are an independent upstream test-deps resolve issue.

## Test plan
- [x] Verified QA suite passes locally on master (`test/qa/qa.jl`, 20/20)
- [x] Verified NeuralPDE env resolves when developing QMC 0.4 + MonteCarloIntegration quasimontecarlo-0.4 branch
- [ ] IntegrationTest workflow on this PR (NeuralPDE NNPDE1/NNPDE2)


Made with [Cursor](https://cursor.com)