### PR TITLE
fix: skip the lattice-rule precompile workload on 32-bit

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -27,8 +27,12 @@ using PrecompileTools: @compile_workload, @setup_workload
         # RandomSample - basic uniform random sampling
         sample(n, lb, ub, RandomSample())
 
-        # LatticeRuleSample - lattice-based sampling
-        sample(n, lb, ub, LatticeRuleSample())
+        # LatticeRuleSample - lattice-based sampling. LatticeRules bounds the point
+        # count by `typemax(UInt32) + 1`, which promotes to UInt32 and wraps to 0
+        # where `Int` is 32 bits, so every lattice rule throws there.
+        if Sys.WORD_SIZE > 32
+            sample(n, lb, ub, LatticeRuleSample())
+        end
 
         # GoldenSample (Kronecker) - golden ratio based sampling
         sample(n, lb, ub, GoldenSample())
@@ -47,7 +51,9 @@ using PrecompileTools: @compile_workload, @setup_workload
         sample(n, d, HaltonSample())
         sample(n, d, GridSample())
         sample(n, d, RandomSample())
-        sample(n, d, LatticeRuleSample())
+        if Sys.WORD_SIZE > 32
+            sample(n, d, LatticeRuleSample())
+        end
         sample(n, d, GoldenSample())
         sample(n, d, KroneckerSample(d))
         sample(64, d, FaureSample())


### PR DESCRIPTION
`LatticeRules` bounds a rule's point count by `typemax(UInt32) + 1`, which promotes to `UInt32` where `Int` is 32 bits, wraps to 0, and inverts the guard, so `LatticeRule32(s)` throws for every `s`. The precompile workload calls it unconditionally, which fails precompilation and makes `using QuasiMonteCarlo` unusable on any 32-bit build.