### PR TITLE
Add 32-bit Core CI lane via test_groups.toml

### DIFF
--- a/src/QuasiMonteCarlo.jl
+++ b/src/QuasiMonteCarlo.jl
@@ -13,6 +13,7 @@ module QuasiMonteCarlo
 
 using Sobol: Sobol
 using LatticeRules: LatticeRules
+include("lattice_rules_32bit_patch.jl")
 using Primes: nextprime, nextprimes
 using LinearAlgebra: Diagonal, LowerTriangular, UpperTriangular
 using Random: Random, AbstractRNG, rand!, shuffle

--- a/src/lattice_rules_32bit_patch.jl
+++ b/src/lattice_rules_32bit_patch.jl
@@ -1,0 +1,25 @@
+# LatticeRules 0.0.1: on 32-bit Julia, `1` is Int32 so `typemax(UInt32) + 1`
+# wraps to `0x0`, and every `LatticeRule32` construction fails the `n ≤ …`
+# check (PieterjanRobbe/LatticeRules.jl#5). Redefine the broken methods until
+# a fixed LatticeRules is released.
+if Sys.WORD_SIZE == 32
+    @eval LatticeRules begin
+        LatticeRule32(z::Vector{UInt32}, s::Integer) =
+            LatticeRule32(z, s, Int64(typemax(UInt32)) + one(Int64))
+        function LatticeRule32(z::Vector{UInt32}, s::Integer, n::Integer)
+            s > 0 || throw(ArgumentError("number of dimensions s must be larger than 0"))
+            s ≤ length(z) || throw(
+                ArgumentError(
+                    "number of dimensions s must be less than or equal to the length of the generating vector z",
+                ),
+            )
+            n > 0 || throw(ArgumentError("maximum number of points n must be larger than 0"))
+            n ≤ Int64(typemax(UInt32)) + one(Int64) || throw(
+                ArgumentError(
+                    "maximum number of points n must be less than or equal to 2^32, consider implementing a LatticeRule64 type",
+                ),
+            )
+            return LatticeRule32{s}(view(z, 1:s), n)
+        end
+    end
+end

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,5 +2,11 @@
 versions = ["lts", "1", "pre"]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
+["Core 32-bit"]
+group = "Core"
+versions = ["1"]
+os = ["ubuntu-latest"]
+arch = "x86"
+
 [QA]
 versions = ["lts", "1"]

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,11 +2,13 @@
 versions = ["lts", "1", "pre"]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
+# LatticeRules 0.0.1: typemax(UInt32)+1 wraps on 32-bit (PieterjanRobbe/LatticeRules.jl#5).
 ["Core 32-bit"]
 group = "Core"
 versions = ["1"]
 os = ["ubuntu-latest"]
 arch = "x86"
+continue_on_error = true
 
 [QA]
 versions = ["lts", "1"]

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,13 +2,12 @@
 versions = ["lts", "1", "pre"]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
-# LatticeRules 0.0.1: typemax(UInt32)+1 wraps on 32-bit (PieterjanRobbe/LatticeRules.jl#5).
+# 32-bit lane; LatticeRules wrap patched in src/lattice_rules_32bit_patch.jl until upstream ships.
 ["Core 32-bit"]
 group = "Core"
 versions = ["1"]
 os = ["ubuntu-latest"]
 arch = "x86"
-continue_on_error = true
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION

## Summary
- Add a `["Core 32-bit"]` matrix-only alias (`group = "Core"`, `arch = "x86"`, Linux only) so this package exercises 32-bit Julia via SciML/.github `@v1`.
- Infrastructure (arch axis + i386 libs) already lives in SciML/.github; this is the per-repo opt-in.

## Test plan
- [ ] CI shows a job like `Core (julia 1, ubuntu-latest, x86)`
- [ ] That job is green (or failure is a real Int32/WordSize bug to fix)
