### PR TITLE
Release 0.4.4: HypothesisTests 0.12 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuasiMonteCarlo"
 uuid = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 authors = ["ludoro <ludovicobessi@gmail.com>, Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
## Summary
- Bump package version to **0.4.4** so General can register the already-merged HypothesisTests 0.12 compat from #188.
- Registered 0.4.3 still advertises HT 0.10.4/0.11 only; without a new release, dependents cannot resolve HT 0.12 from the registry.

## Test plan
- [ ] CI green on Core (incl. x86 if present)
- [ ] After merge: `@JuliaRegistrator register`

Made with [Cursor](https://cursor.com)