### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,32 @@
+using QuasiMonteCarlo, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+lb = zeros(4)
+ub = ones(4)
+n = 10_000
+
+# =============================================================================
+# Sequence generation
+# =============================================================================
+
+SUITE["sample"] = BenchmarkGroup()
+
+SUITE["sample"]["sobol"] = @benchmarkable QuasiMonteCarlo.sample(
+    $n, $lb, $ub, SobolSample()
+)
+SUITE["sample"]["halton"] = @benchmarkable QuasiMonteCarlo.sample(
+    $n, $lb, $ub, HaltonSample()
+)
+SUITE["sample"]["latinhypercube"] = @benchmarkable QuasiMonteCarlo.sample(
+    $n, $lb, $ub, LatinHypercubeSample()
+)
+SUITE["sample"]["faure"] = @benchmarkable QuasiMonteCarlo.sample(
+    9375, $lb, $ub, FaureSample()
+)
+SUITE["sample"]["kronecker"] = @benchmarkable QuasiMonteCarlo.sample(
+    $n, $lb, $ub, KroneckerSample()
+)
+SUITE["sample"]["lattice_rule"] = @benchmarkable QuasiMonteCarlo.sample(
+    $n, $lb, $ub, LatticeRuleSample()
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~36s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~36s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md